### PR TITLE
refactor/#6: remove unused DistinctBy

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Toponyms/GetByStreetcodeId/GetToponymsByStreetcodeIdHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Toponyms/GetByStreetcodeId/GetToponymsByStreetcodeIdHandler.cs
@@ -2,7 +2,6 @@ using AutoMapper;
 using FluentResults;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
-using Streetcode.BLL.DTO.AdditionalContent.Subtitles;
 using Streetcode.BLL.DTO.Toponyms;
 using Streetcode.BLL.Interfaces.Logging;
 using Streetcode.DAL.Repositories.Interfaces.Base;
@@ -28,10 +27,9 @@ public class GetToponymsByStreetcodeIdHandler : IRequestHandler<GetToponymsByStr
             .ToponymRepository
             .GetAllAsync(
                 predicate: sc => sc.Streetcodes.Any(s => s.Id == request.StreetcodeId),
-                include: scl => scl
-                    .Include(sc => sc.Coordinate));
-        toponyms.DistinctBy(x => x.StreetName);
-        if (toponyms is null)
+                include: scl => scl.Include(sc => sc.Coordinate));
+
+        if (toponyms is null || !toponyms.Any())
         {
             string errorMsg = $"Cannot find any toponym by the streetcode id: {request.StreetcodeId}";
             _logger.LogError(request, errorMsg);


### PR DESCRIPTION
dev

## Code reviewers

- [ ] @DeorixProg
- [ ] @weazy12
- [ ] @Markian-Grybok

## Summary of issue

The method `Handle` in `GetToponymsByStreetcodeIdQuery` contained an unused call to `DistinctBy`, which did not affect the result since the returned value was not utilized.
#6 

## Summary of change

* Removed the unused `DistinctBy` call.
* Added a `.Any()` check in the null condition to handle empty collections properly.
* Improved code readability

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
