### PR TITLE
Feature/116/add art gallery crud

### DIFF
--- a/Streetcode/Streetcode.BLL/DTO/ArtGallery/StreetcodeArtSlideCreateUpdateDTO.cs
+++ b/Streetcode/Streetcode.BLL/DTO/ArtGallery/StreetcodeArtSlideCreateUpdateDTO.cs
@@ -1,13 +1,16 @@
-﻿using Streetcode.BLL.DTO.Media.Art;
+﻿using Streetcode.BLL.DTO.Interfaces;
+using Streetcode.BLL.DTO.Media.Art;
+using Streetcode.BLL.Enums;
 using Streetcode.DAL.Enums;
 
 namespace Streetcode.BLL.DTO.ArtGallery;
 
-public class StreetcodeArtSlideCreateUpdateDTO
+public class StreetcodeArtSlideCreateUpdateDTO : IModelState
 {
     public int Id { get; set; }
     public int Index { get; set; }
     public int? StreetcodeId { get; set; }
     public GallerySlideTemplate Template { get; set; }
     public IEnumerable<StreetcodeArtCreateUpdateDTO> StreetcodeArts { get; set; } = new List<StreetcodeArtCreateUpdateDTO>();
+    public ModelState ModelState { get; set; }
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/Create/StreetcodeCreateHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/Create/StreetcodeCreateHandler.cs
@@ -1,14 +1,16 @@
 ﻿using AutoMapper;
 using FluentResults;
 using MediatR;
+using Streetcode.BLL.DTO.AdditionalContent.Tag;
+using Streetcode.BLL.DTO.ArtGallery;
+using Streetcode.BLL.DTO.Media.Art;
+using Streetcode.BLL.DTO.Media.Images;
 using Streetcode.BLL.DTO.Streetcode;
 using Streetcode.BLL.Interfaces.Logging;
-using Streetcode.DAL.Repositories.Interfaces.Base;
-using Streetcode.DAL.Entities.Streetcode;
-using Streetcode.DAL.Entities.Media.Images;
-using Streetcode.BLL.DTO.Media.Images;
-using Streetcode.BLL.DTO.AdditionalContent.Tag;
 using Streetcode.DAL.Entities.AdditionalContent;
+using Streetcode.DAL.Entities.Media.Images;
+using Streetcode.DAL.Entities.Streetcode;
+using Streetcode.DAL.Repositories.Interfaces.Base;
 
 namespace Streetcode.BLL.MediatR.Streetcode.Streetcode.Create;
 
@@ -39,6 +41,10 @@ public class StreetcodeCreateHandler : IRequestHandler<StreetcodeCreateCommand, 
                 _repositoryWrapper.StreetcodeRepository.Create(streetcodeEntity);
 
                 var saveResult = await _repositoryWrapper.SaveChangesAsync();
+                if (saveResult == 0)
+                {
+                    return CreateErrorResult<StreetcodeDTO>(request, "Failed to save streetcode to database");
+                }
 
                 var imagesDetails = request.NewStreetcode.ImagesDetails;
                 if (imagesDetails is null || !imagesDetails.Any())
@@ -60,15 +66,15 @@ public class StreetcodeCreateHandler : IRequestHandler<StreetcodeCreateCommand, 
                 }
 
                 await AddTags(streetcodeEntity, request.NewStreetcode.Tags);
-                await _repositoryWrapper.SaveChangesAsync();
-
                 await AddImagesDetails(request.NewStreetcode.ImagesDetails);
+                saveResult = await _repositoryWrapper.SaveChangesAsync();
 
-                await _repositoryWrapper.SaveChangesAsync();
                 if (saveResult == 0)
                 {
                     return CreateErrorResult<StreetcodeDTO>(request, "Failed to save streetcode to database");
                 }
+
+                await AddArtGalleryAsync(streetcodeEntity, request.NewStreetcode.Arts, request.NewStreetcode.StreetcodeArtSlides);
 
                 var resultDto = _mapper.Map<StreetcodeDTO>(streetcodeEntity);
 
@@ -144,5 +150,85 @@ public class StreetcodeCreateHandler : IRequestHandler<StreetcodeCreateCommand, 
         }
 
         await _repositoryWrapper.StreetcodeTagIndexRepository.CreateRangeAsync(indexedTags);
+    }
+
+    private async Task AddArtGalleryAsync(StreetcodeContent streetcode, IEnumerable<ArtCreateUpdateDTO> arts, IEnumerable<StreetcodeArtSlideCreateUpdateDTO> streetcodeArtSlides)
+    {
+        var artSlidesList = streetcodeArtSlides?.ToList() ?? new List<StreetcodeArtSlideCreateUpdateDTO>();
+        var artsList = arts?.ToList() ?? new List<ArtCreateUpdateDTO>();
+
+        if (artSlidesList.Count == 0 && artsList.Count == 0)
+        {
+            return;
+        }
+
+        // Отримуємо список Id артів, які реально використовуються в слайдах
+        var usedArtIds = new HashSet<int>(
+            artSlidesList.SelectMany(slide => slide.StreetcodeArts)
+                         .Select(streetcodeArt => streetcodeArt.ArtId));
+
+        var filteredArts = artsList.Where(art => usedArtIds.Contains(art.Id)).ToList();
+
+        // Перевірка, що всі потрібні ImageId існують
+        var imageIds = filteredArts.Select(a => a.ImageId).Distinct().ToList();
+        var existingImages = await _repositoryWrapper.ImageRepository.GetAllAsync(i => imageIds.Contains(i.Id));
+        var existingImageIds = new HashSet<int>(existingImages.Select(i => i.Id));
+
+        foreach (var artDto in filteredArts)
+        {
+            if (!existingImageIds.Contains(artDto.ImageId))
+            {
+                throw new InvalidOperationException($"Image with ID {artDto.ImageId} does not exist");
+            }
+        }
+
+        // Створюємо Arts
+        var newArts = _mapper.Map<List<Art>>(filteredArts);
+
+        await _repositoryWrapper.ArtRepository.CreateRangeAsync(newArts);
+        await _repositoryWrapper.SaveChangesAsync();
+
+        // Створюємо ArtSlides
+        var newArtSlides = _mapper.Map<List<StreetcodeArtSlide>>(artSlidesList);
+        newArtSlides.ForEach(artSlide => artSlide.StreetcodeId = streetcode.Id);
+
+        await _repositoryWrapper.StreetcodeArtSlideRepository.CreateRangeAsync(newArtSlides);
+        await _repositoryWrapper.SaveChangesAsync();
+
+        // Мапа старих Id => нових Id
+        var artIdMap = filteredArts
+            .Zip(newArts, (placeholderArt, newArt) => new { PlaceholderId = placeholderArt.Id, RealId = newArt.Id })
+            .ToDictionary(x => x.PlaceholderId, x => x.RealId);
+
+        var streetcodeArtEntities = new List<StreetcodeArt>();
+
+        // Створюємо StreetcodeArts
+        for (int i = 0; i < artSlidesList.Count; i++)
+        {
+            var slideDto = artSlidesList[i];
+            var slideId = newArtSlides[i].Id;
+
+            foreach (var streetcodeArtDto in slideDto.StreetcodeArts)
+            {
+                // Перевіряємо, що ArtId існує у мапі
+                if (!artIdMap.TryGetValue(streetcodeArtDto.ArtId, out var newArtId))
+                {
+                    throw new KeyNotFoundException($"Art ID '{streetcodeArtDto.ArtId}' not found in the mapped arts.");
+                }
+
+                var streetcodeArtEntity = _mapper.Map<StreetcodeArt>(streetcodeArtDto);
+                streetcodeArtEntity.StreetcodeId = streetcode.Id;
+                streetcodeArtEntity.StreetcodeArtSlideId = slideId;
+                streetcodeArtEntity.ArtId = newArtId;
+
+                streetcodeArtEntities.Add(streetcodeArtEntity);
+            }
+        }
+
+        if (streetcodeArtEntities.Count != 0)
+        {
+            await _repositoryWrapper.StreetcodeArtRepository.CreateRangeAsync(streetcodeArtEntities);
+            await _repositoryWrapper.SaveChangesAsync();
+        }
     }
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/Create/StreetcodeCreateHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/Create/StreetcodeCreateHandler.cs
@@ -162,14 +162,14 @@ public class StreetcodeCreateHandler : IRequestHandler<StreetcodeCreateCommand, 
             return;
         }
 
-        // Отримуємо список Id артів, які реально використовуються в слайдах
+        // Get the list of Art IDs that are actually used in slides
         var usedArtIds = new HashSet<int>(
             artSlidesList.SelectMany(slide => slide.StreetcodeArts)
                          .Select(streetcodeArt => streetcodeArt.ArtId));
 
         var filteredArts = artsList.Where(art => usedArtIds.Contains(art.Id)).ToList();
 
-        // Перевірка, що всі потрібні ImageId існують
+        // Verify that all required ImageIds exist
         var imageIds = filteredArts.Select(a => a.ImageId).Distinct().ToList();
         var existingImages = await _repositoryWrapper.ImageRepository.GetAllAsync(i => imageIds.Contains(i.Id));
         var existingImageIds = new HashSet<int>(existingImages.Select(i => i.Id));
@@ -182,27 +182,27 @@ public class StreetcodeCreateHandler : IRequestHandler<StreetcodeCreateCommand, 
             }
         }
 
-        // Створюємо Arts
+        // Create Arts
         var newArts = _mapper.Map<List<Art>>(filteredArts);
 
         await _repositoryWrapper.ArtRepository.CreateRangeAsync(newArts);
         await _repositoryWrapper.SaveChangesAsync();
 
-        // Створюємо ArtSlides
+        // Create ArtSlides
         var newArtSlides = _mapper.Map<List<StreetcodeArtSlide>>(artSlidesList);
         newArtSlides.ForEach(artSlide => artSlide.StreetcodeId = streetcode.Id);
 
         await _repositoryWrapper.StreetcodeArtSlideRepository.CreateRangeAsync(newArtSlides);
         await _repositoryWrapper.SaveChangesAsync();
 
-        // Мапа старих Id => нових Id
+        // Map old Ids => new Ids
         var artIdMap = filteredArts
             .Zip(newArts, (placeholderArt, newArt) => new { PlaceholderId = placeholderArt.Id, RealId = newArt.Id })
             .ToDictionary(x => x.PlaceholderId, x => x.RealId);
 
         var streetcodeArtEntities = new List<StreetcodeArt>();
 
-        // Створюємо StreetcodeArts
+        // Create StreetcodeArts
         for (int i = 0; i < artSlidesList.Count; i++)
         {
             var slideDto = artSlidesList[i];
@@ -210,7 +210,7 @@ public class StreetcodeCreateHandler : IRequestHandler<StreetcodeCreateCommand, 
 
             foreach (var streetcodeArtDto in slideDto.StreetcodeArts)
             {
-                // Перевіряємо, що ArtId існує у мапі
+                // Ensure that ArtId exists in the map
                 if (!artIdMap.TryGetValue(streetcodeArtDto.ArtId, out var newArtId))
                 {
                     throw new KeyNotFoundException($"Art ID '{streetcodeArtDto.ArtId}' not found in the mapped arts.");

--- a/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/Update/UpdateStreetcodeHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Streetcode/Streetcode/Update/UpdateStreetcodeHandler.cs
@@ -1,22 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using AutoMapper;
+﻿using AutoMapper;
 using FluentResults;
 using MediatR;
 using Streetcode.BLL.DTO.AdditionalContent.Tag;
+using Streetcode.BLL.DTO.ArtGallery;
 using Streetcode.BLL.DTO.Interfaces;
+using Streetcode.BLL.DTO.Media.Art;
 using Streetcode.BLL.DTO.Media.Images;
-using Streetcode.BLL.DTO.Streetcode;
-using Streetcode.BLL.DTO.Streetcode.Update;
 using Streetcode.BLL.Enums;
 using Streetcode.BLL.Interfaces.Logging;
 using Streetcode.DAL.Entities.AdditionalContent;
 using Streetcode.DAL.Entities.Media.Images;
+using Streetcode.DAL.Entities.Streetcode;
 using Streetcode.DAL.Repositories.Interfaces.Base;
-using Streetcode.DAL.Repositories.Realizations.Base;
 
 namespace Streetcode.BLL.MediatR.Streetcode.Streetcode.Update
 {
@@ -54,6 +49,7 @@ namespace Streetcode.BLL.MediatR.Streetcode.Streetcode.Update
                     existingEntity.UpdatedAt = DateTime.UtcNow;
                     await UpdateTags(request.Streetcode.Tags);
                     await UpdateImagesAsync(request.Streetcode.Images);
+                    await UpdateArtGalleryAsync(existingEntity.Id, request.Streetcode.Arts, request.Streetcode.StreetcodeArtSlides);
 
                     _repositoryWrapper.StreetcodeRepository.Update(existingEntity);
 
@@ -113,6 +109,184 @@ namespace Streetcode.BLL.MediatR.Streetcode.Streetcode.Update
 
             _repositoryWrapper.ImageRepository.DeleteRange(_mapper.Map<IEnumerable<Image>>(toDelete));
             await _repositoryWrapper.StreetcodeImageRepository.CreateRangeAsync(_mapper.Map<IEnumerable<StreetcodeImage>>(toCreate));
+        }
+
+        private async Task UpdateArtGalleryAsync(int streetcodeId, IEnumerable<ArtCreateUpdateDTO> arts, IEnumerable<StreetcodeArtSlideCreateUpdateDTO> streetcodeArtSlides)
+        {
+            var artsList = arts?.ToList() ?? new List<ArtCreateUpdateDTO>();
+            var artSlidesList = streetcodeArtSlides?.ToList() ?? new List<StreetcodeArtSlideCreateUpdateDTO>();
+
+            if (artsList.Count == 0 && artSlidesList.Count == 0)
+            {
+                return;
+            }
+
+            // Update Arts
+            await UpdateArtsAsync(artsList);
+
+            // Update StreetcodeArtSlides
+            await UpdateStreetcodeArtSlidesAsync(streetcodeId, artSlidesList);
+            await _repositoryWrapper.SaveChangesAsync();
+
+            // Update StreetcodeArts (relationships between slides and arts)
+            await UpdateStreetcodeArtsAsync(streetcodeId, artSlidesList);
+            await _repositoryWrapper.SaveChangesAsync();
+        }
+
+        private async Task UpdateArtsAsync(IEnumerable<ArtCreateUpdateDTO> arts)
+        {
+            if (arts is null || !arts.Any())
+            {
+                return;
+            }
+
+            var (toUpdate, toCreate, toDelete) = CategorizeItems(arts);
+
+            // Validate that images exist for new and updated arts
+            var artsNeedingImageValidation = toCreate.Concat(toUpdate);
+            var imageIds = artsNeedingImageValidation.Select(a => a.ImageId).Distinct().ToList();
+
+            if (imageIds.Any())
+            {
+                var existingImages = await _repositoryWrapper.ImageRepository.GetAllAsync(i => imageIds.Contains(i.Id));
+                var existingImageIds = new HashSet<int>(existingImages.Select(i => i.Id));
+
+                foreach (var artDto in artsNeedingImageValidation)
+                {
+                    if (!existingImageIds.Contains(artDto.ImageId))
+                    {
+                        throw new InvalidOperationException($"Image with ID {artDto.ImageId} does not exist");
+                    }
+                }
+            }
+
+            // Delete arts
+            if (toDelete.Any())
+            {
+                _repositoryWrapper.ArtRepository.DeleteRange(_mapper.Map<IEnumerable<Art>>(toDelete));
+            }
+
+            // Create new arts
+            if (toCreate.Any())
+            {
+                var newArts = _mapper.Map<IEnumerable<Art>>(toCreate);
+                await _repositoryWrapper.ArtRepository.CreateRangeAsync(newArts);
+            }
+
+            // Update existing arts
+            if (toUpdate.Any())
+            {
+                var updatedArts = _mapper.Map<IEnumerable<Art>>(toUpdate);
+                _repositoryWrapper.ArtRepository.UpdateRange(updatedArts);
+            }
+        }
+
+        private async Task UpdateStreetcodeArtSlidesAsync(int streetcodeId, IEnumerable<StreetcodeArtSlideCreateUpdateDTO> streetcodeArtSlides)
+        {
+            if (streetcodeArtSlides is null || !streetcodeArtSlides.Any())
+            {
+                return;
+            }
+
+            var (toUpdate, toCreate, toDelete) = CategorizeItems(streetcodeArtSlides);
+
+            // Delete slides
+            if (toDelete.Any())
+            {
+                _repositoryWrapper.StreetcodeArtSlideRepository.DeleteRange(_mapper.Map<IEnumerable<StreetcodeArtSlide>>(toDelete));
+            }
+
+            // Create new slides
+            if (toCreate.Any())
+            {
+                var newSlides = _mapper.Map<IEnumerable<StreetcodeArtSlide>>(toCreate).ToList();
+                newSlides.ForEach(slide => slide.StreetcodeId = streetcodeId);
+
+                await _repositoryWrapper.StreetcodeArtSlideRepository.CreateRangeAsync(newSlides);
+            }
+
+            // Update existing slides
+            if (toUpdate.Any())
+            {
+                var updatedSlides = _mapper.Map<IEnumerable<StreetcodeArtSlide>>(toUpdate).ToList();
+                updatedSlides.ForEach(slide => slide.StreetcodeId = streetcodeId);
+
+                _repositoryWrapper.StreetcodeArtSlideRepository.UpdateRange(updatedSlides);
+            }
+        }
+
+        private async Task UpdateStreetcodeArtsAsync(int streetcodeId, IEnumerable<StreetcodeArtSlideCreateUpdateDTO> streetcodeArtSlides)
+        {
+            if (streetcodeArtSlides is null || !streetcodeArtSlides.Any())
+            {
+                return;
+            }
+
+            // Get all existing StreetcodeArts for this streetcode to manage them properly
+            var existingStreetcodeArts = await _repositoryWrapper.StreetcodeArtRepository
+                .GetAllAsync(sa => sa.StreetcodeId == streetcodeId);
+
+            // Delete all existing StreetcodeArts for this streetcode to rebuild them
+            if (existingStreetcodeArts.Any())
+            {
+                _repositoryWrapper.StreetcodeArtRepository.DeleteRange(existingStreetcodeArts);
+            }
+
+            // Create new StreetcodeArts based on the slides
+            var newStreetcodeArts = new List<StreetcodeArt>();
+
+            foreach (var slideDto in streetcodeArtSlides)
+            {
+                // Skip slides marked for deletion
+                if (slideDto.ModelState == ModelState.Deleted)
+                {
+                    continue;
+                }
+
+                // For existing slides, get the slide ID, for new slides we need to get them after creation
+                int slideId = slideDto.Id;
+
+                // If this is a new slide (Created), we need to find its ID after creation
+                if (slideDto.ModelState == ModelState.Created)
+                {
+                    // Find the created slide by matching properties
+                    var createdSlide = await _repositoryWrapper.StreetcodeArtSlideRepository
+                        .GetFirstOrDefaultAsync(s => s.StreetcodeId == streetcodeId &&
+                                                    s.Index == slideDto.Index &&
+                                                    s.Template == slideDto.Template);
+                    if (createdSlide != null)
+                    {
+                        slideId = createdSlide.Id;
+                    }
+                }
+
+                foreach (var streetcodeArtDto in slideDto.StreetcodeArts)
+                {
+                    // Validate that the Art exists
+                    var artExists = await _repositoryWrapper.ArtRepository
+                        .GetFirstOrDefaultAsync(a => a.Id == streetcodeArtDto.ArtId);
+
+                    if (artExists == null)
+                    {
+                        throw new InvalidOperationException($"Art with ID {streetcodeArtDto.ArtId} does not exist");
+                    }
+
+                    var streetcodeArt = new StreetcodeArt
+                    {
+                        StreetcodeId = streetcodeId,
+                        StreetcodeArtSlideId = slideId,
+                        ArtId = streetcodeArtDto.ArtId,
+                        Index = streetcodeArtDto.Index
+                    };
+
+                    newStreetcodeArts.Add(streetcodeArt);
+                }
+            }
+
+            if (newStreetcodeArts.Any())
+            {
+                await _repositoryWrapper.StreetcodeArtRepository.CreateRangeAsync(newStreetcodeArts);
+            }
         }
 
         private static (IEnumerable<T> toUpdate, IEnumerable<T> toCreate, IEnumerable<T> toDelete) CategorizeItems<T>(IEnumerable<T> items)

--- a/Streetcode/Streetcode.XUnitTest/BLL/MediatR/StreetCode/Streetcode/Create/StreetcodeCreateHandlerTest.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/MediatR/StreetCode/Streetcode/Create/StreetcodeCreateHandlerTest.cs
@@ -1,14 +1,22 @@
-﻿using AutoMapper;
+﻿using System.Transactions;
+using AutoMapper;
+using Microsoft.EntityFrameworkCore.Query;
 using Moq;
+using Streetcode.BLL.DTO.AdditionalContent.Tag;
+using Streetcode.BLL.DTO.ArtGallery;
+using Streetcode.BLL.DTO.Media.Art;
+using Streetcode.BLL.DTO.Media.Images;
 using Streetcode.BLL.DTO.Streetcode;
 using Streetcode.BLL.DTO.Streetcode.Create;
+using Streetcode.BLL.Enums;
 using Streetcode.BLL.Interfaces.Logging;
 using Streetcode.BLL.MediatR.Streetcode.Streetcode.Create;
+using Streetcode.DAL.Entities.AdditionalContent;
+using Streetcode.DAL.Entities.Media.Images;
 using Streetcode.DAL.Entities.Streetcode;
+using Streetcode.DAL.Enums;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 using Xunit;
-using Streetcode.BLL.DTO.AdditionalContent.Tag;
-using Streetcode.BLL.DTO.Media.Images;
 
 namespace Streetcode.XUnitTest.BLL.MediatR.StreetCode.StreetCode.Create;
 
@@ -31,6 +39,25 @@ public class StreetcodeCreateHandlerTest
     }
 
     [Fact]
+    public async Task Handle_ValidRequest_ShouldReturnSuccess()
+    {
+        // Arrange
+        var request = CreateValidRequest();
+        var streetcodeEntity = CreateStreetcodeEntity();
+        var streetcodeDto = CreateStreetcodeDTO();
+
+        SetupMocksForCompleteSuccess(request, streetcodeEntity, streetcodeDto);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(streetcodeDto, result.Value);
+        VerifySuccessCalls(request, streetcodeEntity);
+    }
+
+    [Fact]
     public async Task Handle_SaveStreetcodeFails_ShouldReturnFailure()
     {
         // Arrange
@@ -42,17 +69,20 @@ public class StreetcodeCreateHandlerTest
         _mockRepositoryWrapper.Setup(r => r.StreetcodeRepository.Create(streetcodeEntity));
         _mockRepositoryWrapper.Setup(r => r.SaveChangesAsync())
             .ReturnsAsync(0);
+        _mockRepositoryWrapper.Setup(r => r.BeginTransaction())
+            .Returns(new TransactionScope());
 
         // Act
         var result = await _handler.Handle(request, CancellationToken.None);
 
         // Assert
         Assert.True(result.IsFailed);
+        Assert.Contains("Failed to save streetcode to database", result.Errors[0].Message);
         _mockLogger.Verify(l => l.LogError(request, It.IsAny<string>()), Times.Once);
     }
 
     [Fact]
-    public async Task Handle_EmptyImageIds_ShouldReturnFailure()
+    public async Task Handle_EmptyImagesDetails_ShouldReturnFailure()
     {
         // Arrange
         var request = CreateRequestWithEmptyImages();
@@ -69,6 +99,23 @@ public class StreetcodeCreateHandlerTest
     }
 
     [Fact]
+    public async Task Handle_EmptyImageIds_ShouldReturnFailure()
+    {
+        // Arrange
+        var request = CreateRequestWithInvalidImageIds();
+        var streetcodeEntity = CreateStreetcodeEntity();
+
+        SetupMocksForInitialSave(request, streetcodeEntity);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Contains("Image IDs cannot be empty", result.Errors[0].Message);
+    }
+
+    [Fact]
     public async Task Handle_EmptyTags_ShouldReturnFailure()
     {
         // Arrange
@@ -76,56 +123,14 @@ public class StreetcodeCreateHandlerTest
         var streetcodeEntity = CreateStreetcodeEntity();
 
         SetupMocksForInitialSave(request, streetcodeEntity);
-        SetupImagesForSuccess(request);
+        SetupImagesForSuccess();
 
         // Act
         var result = await _handler.Handle(request, CancellationToken.None);
 
         // Assert
         Assert.True(result.IsFailed);
-        Assert.Contains("Object reference not set to an instance of an object.", result.Errors[0].Message);
-    }
-
-    [Fact]
-    public async Task Handle_EmptyImagesDetails_ShouldReturnFailure()
-    {
-        // Arrange
-        var request = CreateRequestWithEmptyImagesDetails();
-        var streetcodeEntity = CreateStreetcodeEntity();
-
-        SetupMocksForInitialSave(request, streetcodeEntity);
-        SetupImagesForSuccess(request);
-        SetupTagsForSuccess(request);
-
-        // Act
-        var result = await _handler.Handle(request, CancellationToken.None);
-
-        // Assert
-        Assert.True(result.IsFailed);
-        Assert.Contains("ImagesDetails cannot be empty", result.Errors[0].Message);
-    }
-
-    [Fact]
-    public async Task Handle_SaveRelationshipsFails_ShouldReturnFailure()
-    {
-        // Arrange
-        var request = CreateValidRequest();
-        var streetcodeEntity = CreateStreetcodeEntity();
-
-        SetupMocksForInitialSave(request, streetcodeEntity);
-        SetupImagesForSuccess(request);
-        SetupTagsForSuccess(request);
-        SetupImagesDetailsForSuccess(request);
-
-        _mockRepositoryWrapper.Setup(r => r.SaveChangesAsync())
-            .ReturnsAsync(0);
-
-        // Act
-        var result = await _handler.Handle(request, CancellationToken.None);
-
-        // Assert
-        Assert.True(result.IsFailed);
-        Assert.Contains("Object reference not set to an instance of an object.", result.Errors[0].Message);
+        Assert.Contains("Tags cannot be empty", result.Errors[0].Message);
     }
 
     [Fact]
@@ -136,6 +141,8 @@ public class StreetcodeCreateHandlerTest
 
         _mockMapper.Setup(m => m.Map<StreetcodeContent>(request.NewStreetcode))
             .Throws(new Exception("Test exception"));
+        _mockRepositoryWrapper.Setup(r => r.BeginTransaction())
+            .Returns(new TransactionScope());
 
         // Act
         var result = await _handler.Handle(request, CancellationToken.None);
@@ -144,6 +151,211 @@ public class StreetcodeCreateHandlerTest
         Assert.True(result.IsFailed);
         Assert.Contains("Test exception", result.Errors[0].Message);
         _mockLogger.Verify(l => l.LogError(request, It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithValidArtsAndSlides_ShouldCreateArtGallerySuccessfully()
+    {
+        // Arrange
+        var request = CreateRequestWithArtGallery();
+        var streetcodeEntity = CreateStreetcodeEntity();
+        var streetcodeDto = CreateStreetcodeDTO();
+
+        SetupMocksForArtGallerySuccess(request, streetcodeEntity, streetcodeDto);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        VerifyArtGalleryCreationCalls();
+    }
+
+    [Fact]
+    public async Task Handle_WithEmptyArtGallery_ShouldSkipArtGalleryCreation()
+    {
+        // Arrange
+        var request = CreateValidRequest(); // No arts or slides
+        var streetcodeEntity = CreateStreetcodeEntity();
+        var streetcodeDto = CreateStreetcodeDTO();
+
+        SetupMocksForCompleteSuccess(request, streetcodeEntity, streetcodeDto);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        // Verify art repositories were not called
+        _mockRepositoryWrapper.Verify(r => r.ArtRepository.CreateRangeAsync(It.IsAny<IEnumerable<Art>>()), Times.Never);
+        _mockRepositoryWrapper.Verify(r => r.StreetcodeArtSlideRepository.CreateRangeAsync(It.IsAny<IEnumerable<StreetcodeArtSlide>>()), Times.Never);
+        _mockRepositoryWrapper.Verify(r => r.StreetcodeArtRepository.CreateRangeAsync(It.IsAny<IEnumerable<StreetcodeArt>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WithNonExistentImageId_ShouldThrowException()
+    {
+        // Arrange
+        var request = CreateRequestWithInvalidImageIdInArt();
+        var streetcodeEntity = CreateStreetcodeEntity();
+
+        SetupMocksForInitialSave(request, streetcodeEntity);
+        SetupImagesForSuccess();
+        SetupTagsForSuccess();
+        SetupImagesDetailsForSuccess();
+
+        // Setup image repository to return null for non-existent image
+        _mockRepositoryWrapper.Setup(r => r.ImageRepository.GetAllAsync(
+                It.IsAny<System.Linq.Expressions.Expression<Func<Image, bool>>>(),
+                It.IsAny<Func<IQueryable<Image>, IIncludableQueryable<Image, object>>>()))
+            .ReturnsAsync([]);
+
+        _mockRepositoryWrapper.Setup(r => r.BeginTransaction())
+            .Returns(new TransactionScope());
+
+        // Act & Assert
+        var result = await _handler.Handle(request, CancellationToken.None);
+        Assert.True(result.IsFailed);
+        Assert.Contains("Image with ID 999 does not exist", result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_WithNonExistentArtId_ShouldThrowException()
+    {
+        // Arrange
+        var request = CreateRequestWithInvalidArtIdInSlide();
+        var streetcodeEntity = CreateStreetcodeEntity();
+
+        SetupMocksForInitialSave(request, streetcodeEntity);
+        SetupImagesForSuccess();
+        SetupTagsForSuccess();
+        SetupImagesDetailsForSuccess();
+
+        // Setup art repository to return null for non-existent art
+        _mockRepositoryWrapper.Setup(r => r.ImageRepository.GetAllAsync(
+        It.IsAny<System.Linq.Expressions.Expression<Func<Image, bool>>>(),
+        It.IsAny<Func<IQueryable<Image>, IIncludableQueryable<Image, object>>>()))
+            .ReturnsAsync([]);
+        _mockMapper.Setup(m => m.Map<List<Art>>(It.IsAny<List<ArtCreateUpdateDTO>>()))
+            .Returns([]);
+
+        _mockMapper.Setup(m => m.Map<List<StreetcodeArtSlide>>(It.IsAny<List<StreetcodeArtSlideCreateUpdateDTO>>()))
+            .Returns([new StreetcodeArtSlide { Id = 1, Index = 0, StreetcodeId = 1 }]);
+
+        _mockRepositoryWrapper.Setup(r => r.StreetcodeArtSlideRepository.CreateRangeAsync(It.IsAny<IEnumerable<StreetcodeArtSlide>>()))
+            .Callback<IEnumerable<StreetcodeArtSlide>>(slides =>
+            {
+                // Simulate setting IDs for created entities
+                var slideList = slides.ToList();
+                for (int i = 0; i < slideList.Count; i++)
+                {
+                    slideList[i].Id = i + 1;
+                }
+            })
+            .Returns(Task.CompletedTask);
+
+        _mockRepositoryWrapper.Setup(r => r.ArtRepository.GetFirstOrDefaultAsync(
+                It.IsAny<System.Linq.Expressions.Expression<Func<Art, bool>>>(),
+                It.IsAny<Func<IQueryable<Art>, IIncludableQueryable<Art, object>>>()))
+            .ReturnsAsync((Art?)null);
+
+        _mockRepositoryWrapper.Setup(r => r.BeginTransaction())
+            .Returns(new TransactionScope());
+
+        // Act & Assert
+        var result = await _handler.Handle(request, CancellationToken.None);
+        Assert.True(result.IsFailed);
+        Assert.Contains("Art ID '999' not found in the mapped arts.", result.Errors[0].Message);
+    }
+
+    [Fact]
+    public async Task Handle_WithFilteredArts_ShouldOnlyCreateUsedArts()
+    {
+        // Arrange
+        var request = CreateRequestWithUnusedArts();
+        var streetcodeEntity = CreateStreetcodeEntity();
+        var streetcodeDto = CreateStreetcodeDTO();
+
+        SetupMocksForFilteredArtsSuccess(request, streetcodeEntity, streetcodeDto);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        // Verify that only arts referenced in slides were created
+        _mockRepositoryWrapper.Verify(
+            r => r.ArtRepository.CreateRangeAsync(
+                It.Is<IEnumerable<Art>>(arts => arts.Count() == 2)),
+            Times.Once); // Only 2 out of 3 arts should be created
+    }
+
+    [Fact]
+    public async Task Handle_WithMultipleSlides_ShouldCreateAllSlidesAndArts()
+    {
+        // Arrange
+        var request = CreateRequestWithMultipleSlides();
+        var streetcodeEntity = CreateStreetcodeEntity();
+        var streetcodeDto = CreateStreetcodeDTO();
+
+        SetupMocksForMultipleSlidesSuccess(request, streetcodeEntity, streetcodeDto);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        // Verify multiple slides and arts were created
+        _mockRepositoryWrapper.Verify(
+            r => r.StreetcodeArtSlideRepository.CreateRangeAsync(
+                It.Is<IEnumerable<StreetcodeArtSlide>>(slides => slides.Count() == 2)),
+            Times.Once);
+        _mockRepositoryWrapper.Verify(
+            r => r.StreetcodeArtRepository.CreateRangeAsync(
+                It.Is<IEnumerable<StreetcodeArt>>(streetcodeArts => streetcodeArts.Count() == 3)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithArtGallery_ShouldSetCorrectRelationships()
+    {
+        // Arrange
+        var request = CreateRequestWithArtGallery();
+        var streetcodeEntity = CreateStreetcodeEntity();
+        var streetcodeDto = CreateStreetcodeDTO();
+
+        var capturedArtSlides = new List<StreetcodeArtSlide>();
+        var capturedStreetcodeArts = new List<StreetcodeArt>();
+
+        SetupMocksForArtGallerySuccess(request, streetcodeEntity, streetcodeDto);
+
+        _mockRepositoryWrapper.Setup(r => r.StreetcodeArtSlideRepository.CreateRangeAsync(It.IsAny<IEnumerable<StreetcodeArtSlide>>()))
+            .Callback<IEnumerable<StreetcodeArtSlide>>(capturedArtSlides.AddRange)
+            .Returns(Task.CompletedTask);
+
+        _mockRepositoryWrapper.Setup(r => r.StreetcodeArtRepository.CreateRangeAsync(It.IsAny<IEnumerable<StreetcodeArt>>()))
+            .Callback<IEnumerable<StreetcodeArt>>(capturedStreetcodeArts.AddRange)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        // Verify relationships are set correctly
+        Assert.All(capturedArtSlides, slide => Assert.Equal(streetcodeEntity.Id, slide.StreetcodeId));
+        Assert.All(
+            capturedStreetcodeArts,
+            streetcodeArt =>
+            {
+                Assert.Equal(streetcodeEntity.Id, streetcodeArt.StreetcodeId);
+                Assert.True(streetcodeArt.StreetcodeArtSlideId > 0);
+                Assert.True(streetcodeArt.ArtId > 0);
+            });
     }
 
     private StreetcodeCreateCommand CreateValidRequest()
@@ -155,15 +367,140 @@ public class StreetcodeCreateHandlerTest
             Index = 1,
             Teaser = "Test teaser",
             DateString = "2024",
+            StreetcodeType = StreetcodeType.Person,
+            Status = StreetcodeStatus.Published,
             ImagesDetails = new List<ImageDetailsDto>
             {
-                new ImageDetailsDto { ImageId = 1, Alt = "Test image" }
+                new ImageDetailsDto { ImageId = 1, Alt = "1" }
             },
             Tags = new List<StreetcodeTagDTO>
             {
-                new StreetcodeTagDTO { Title = "Test Tag" }
+                new StreetcodeTagDTO { Id = 1, Title = "Test Tag", IsVisible = true }
             }
         });
+    }
+
+    private StreetcodeCreateCommand CreateRequestWithArtGallery()
+    {
+        var request = CreateValidRequest();
+        request.NewStreetcode.Arts = new List<ArtCreateUpdateDTO>
+        {
+            new ArtCreateUpdateDTO { Id = 1, Title = "Art 1", Description = "Desc 1", ImageId = 1, ModelState = ModelState.Created },
+            new ArtCreateUpdateDTO { Id = 2, Title = "Art 2", Description = "Desc 2", ImageId = 2, ModelState = ModelState.Created }
+        };
+        request.NewStreetcode.StreetcodeArtSlides = new List<StreetcodeArtSlideCreateUpdateDTO>
+        {
+            new StreetcodeArtSlideCreateUpdateDTO
+            {
+                Index = 0,
+                Template = GallerySlideTemplate.OneToTwo,
+                StreetcodeArts = new List<StreetcodeArtCreateUpdateDTO>
+                {
+                    new StreetcodeArtCreateUpdateDTO { Index = 0, ArtId = 1 },
+                    new StreetcodeArtCreateUpdateDTO { Index = 1, ArtId = 2 }
+                }
+            }
+        };
+        return request;
+    }
+
+    private StreetcodeCreateCommand CreateRequestWithUnusedArts()
+    {
+        var request = CreateValidRequest();
+        request.NewStreetcode.Arts = new List<ArtCreateUpdateDTO>
+        {
+            new ArtCreateUpdateDTO { Id = 1, Title = "Art 1", Description = "Desc 1", ImageId = 1, ModelState = ModelState.Created },
+            new ArtCreateUpdateDTO { Id = 2, Title = "Art 2", Description = "Desc 2", ImageId = 2, ModelState = ModelState.Created },
+            new ArtCreateUpdateDTO { Id = 3, Title = "Art 3", Description = "Desc 3", ImageId = 3, ModelState = ModelState.Created } // Not used in slides
+        };
+        request.NewStreetcode.StreetcodeArtSlides = new List<StreetcodeArtSlideCreateUpdateDTO>
+        {
+            new StreetcodeArtSlideCreateUpdateDTO
+            {
+                Index = 0,
+                Template = GallerySlideTemplate.OneToTwo,
+                StreetcodeArts = new List<StreetcodeArtCreateUpdateDTO>
+                {
+                    new StreetcodeArtCreateUpdateDTO { Index = 0, ArtId = 1 },
+                    new StreetcodeArtCreateUpdateDTO { Index = 1, ArtId = 2 }
+                }
+            }
+        };
+        return request;
+    }
+
+    private StreetcodeCreateCommand CreateRequestWithMultipleSlides()
+    {
+        var request = CreateValidRequest();
+        request.NewStreetcode.Arts = new List<ArtCreateUpdateDTO>
+        {
+            new ArtCreateUpdateDTO { Id = 1, Title = "Art 1", Description = "Desc 1", ImageId = 1, ModelState = ModelState.Created },
+            new ArtCreateUpdateDTO { Id = 2, Title = "Art 2", Description = "Desc 2", ImageId = 2, ModelState = ModelState.Created },
+            new ArtCreateUpdateDTO { Id = 3, Title = "Art 3", Description = "Desc 3", ImageId = 3, ModelState = ModelState.Created }
+        };
+        request.NewStreetcode.StreetcodeArtSlides = new List<StreetcodeArtSlideCreateUpdateDTO>
+        {
+            new StreetcodeArtSlideCreateUpdateDTO
+            {
+                Index = 0,
+                Template = GallerySlideTemplate.OneToTwo,
+                StreetcodeArts = new List<StreetcodeArtCreateUpdateDTO>
+                {
+                    new StreetcodeArtCreateUpdateDTO { Index = 0, ArtId = 1 },
+                    new StreetcodeArtCreateUpdateDTO { Index = 1, ArtId = 2 }
+                }
+            },
+            new StreetcodeArtSlideCreateUpdateDTO
+            {
+                Index = 1,
+                Template = GallerySlideTemplate.OneAndTwo,
+                StreetcodeArts = new List<StreetcodeArtCreateUpdateDTO>
+                {
+                    new StreetcodeArtCreateUpdateDTO { Index = 0, ArtId = 3 }
+                }
+            }
+        };
+        return request;
+    }
+
+    private StreetcodeCreateCommand CreateRequestWithInvalidImageIdInArt()
+    {
+        var request = CreateValidRequest();
+        request.NewStreetcode.Arts = new List<ArtCreateUpdateDTO>
+        {
+            new ArtCreateUpdateDTO { Id = 1, Title = "Art 1", Description = "Desc 1", ImageId = 999, ModelState = ModelState.Created }
+        };
+        request.NewStreetcode.StreetcodeArtSlides = new List<StreetcodeArtSlideCreateUpdateDTO>
+        {
+            new StreetcodeArtSlideCreateUpdateDTO
+            {
+                Index = 0,
+                Template = GallerySlideTemplate.OneToTwo,
+                StreetcodeArts = new List<StreetcodeArtCreateUpdateDTO>
+                {
+                    new StreetcodeArtCreateUpdateDTO { Index = 0, ArtId = 1 },
+                }
+            }
+        };
+        return request;
+    }
+
+    private StreetcodeCreateCommand CreateRequestWithInvalidArtIdInSlide()
+    {
+        var request = CreateValidRequest();
+        request.NewStreetcode.StreetcodeArtSlides = new List<StreetcodeArtSlideCreateUpdateDTO>
+        {
+            new StreetcodeArtSlideCreateUpdateDTO
+            {
+                Index = 0,
+                Template = GallerySlideTemplate.OneToTwo,
+                StreetcodeArts = new List<StreetcodeArtCreateUpdateDTO>
+                {
+                    new StreetcodeArtCreateUpdateDTO { Index = 0, ArtId = 999 }
+                }
+            }
+        };
+        return request;
     }
 
     private StreetcodeCreateCommand CreateRequestWithEmptyImages()
@@ -173,17 +510,21 @@ public class StreetcodeCreateHandlerTest
         return request;
     }
 
+    private StreetcodeCreateCommand CreateRequestWithInvalidImageIds()
+    {
+        var request = CreateValidRequest();
+        request.NewStreetcode.ImagesDetails = new List<ImageDetailsDto>
+        {
+            new ImageDetailsDto { ImageId = 0, Alt = "Invalid" },
+            new ImageDetailsDto { ImageId = -1, Alt = "Invalid" }
+        };
+        return request;
+    }
+
     private StreetcodeCreateCommand CreateRequestWithEmptyTags()
     {
         var request = CreateValidRequest();
         request.NewStreetcode.Tags = new List<StreetcodeTagDTO>();
-        return request;
-    }
-
-    private StreetcodeCreateCommand CreateRequestWithEmptyImagesDetails()
-    {
-        var request = CreateValidRequest();
-        request.NewStreetcode.ImagesDetails = new List<ImageDetailsDto>();
         return request;
     }
 
@@ -209,12 +550,90 @@ public class StreetcodeCreateHandlerTest
         };
     }
 
-    private void SetupMocksForSuccess(StreetcodeCreateCommand request, StreetcodeContent entity, StreetcodeDTO dto)
+    private void SetupMocksForCompleteSuccess(StreetcodeCreateCommand request, StreetcodeContent entity, StreetcodeDTO dto)
     {
         SetupMocksForInitialSave(request, entity);
-        SetupImagesForSuccess(request);
-        SetupTagsForSuccess(request);
-        SetupImagesDetailsForSuccess(request);
+        SetupImagesForSuccess();
+        SetupTagsForSuccess();
+        SetupImagesDetailsForSuccess();
+
+        _mockRepositoryWrapper.Setup(r => r.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        _mockMapper.Setup(m => m.Map<StreetcodeDTO>(entity))
+            .Returns(dto);
+    }
+
+    private void SetupMocksForArtGallerySuccess(StreetcodeCreateCommand request, StreetcodeContent entity, StreetcodeDTO dto)
+    {
+        SetupMocksForInitialSave(request, entity);
+        SetupImagesForSuccess();
+        SetupTagsForSuccess();
+        SetupImagesDetailsForSuccess();
+        SetupArtCreationForSuccess(
+            new List<Art>
+            {
+                new Art { Id = 1, Title = "Art 1", ImageId = 1 },
+                new Art { Id = 2, Title = "Art 2", ImageId = 2 },
+                new Art { Id = 3, Title = "Art 3", ImageId = 3 }
+            },
+            [
+                new() { Id = 1 },
+                new() { Id = 2 }
+            ]);
+        SetupArtSlideCreationForSuccess();
+
+        _mockRepositoryWrapper.Setup(r => r.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        _mockMapper.Setup(m => m.Map<StreetcodeDTO>(entity))
+            .Returns(dto);
+    }
+
+    private void SetupMocksForFilteredArtsSuccess(StreetcodeCreateCommand request, StreetcodeContent entity, StreetcodeDTO dto)
+    {
+        SetupMocksForInitialSave(request, entity);
+        SetupImagesForSuccess();
+        SetupTagsForSuccess();
+        SetupImagesDetailsForSuccess();
+        SetupArtCreationForSuccess(
+            new List<Art>
+            {
+                new Art { Id = 1, Title = "Art 1", ImageId = 1 },
+                new Art { Id = 2, Title = "Art 2", ImageId = 2 },
+            },
+            [
+                new() { Id = 1 },
+                new() { Id = 2 }
+            ]);
+        SetupArtSlideCreationForSuccess();
+
+        _mockRepositoryWrapper.Setup(r => r.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        _mockMapper.Setup(m => m.Map<StreetcodeDTO>(entity))
+            .Returns(dto);
+    }
+
+    private void SetupMocksForMultipleSlidesSuccess(StreetcodeCreateCommand request, StreetcodeContent entity, StreetcodeDTO dto)
+    {
+        SetupMocksForInitialSave(request, entity);
+        SetupImagesForSuccess();
+        SetupTagsForSuccess();
+        SetupImagesDetailsForSuccess();
+        SetupArtCreationForSuccess(
+            new List<Art>
+            {
+                new Art { Id = 1, Title = "Art 1", ImageId = 1 },
+                new Art { Id = 2, Title = "Art 2", ImageId = 2 },
+                new Art { Id = 3, Title = "Art 3", ImageId = 3 }
+            },
+            [
+                new() { Id = 1 },
+                new() { Id = 2 },
+                new() { Id = 3 }
+            ]);
+        SetupArtSlideCreationForSuccess();
 
         _mockRepositoryWrapper.Setup(r => r.SaveChangesAsync())
             .ReturnsAsync(1);
@@ -231,24 +650,94 @@ public class StreetcodeCreateHandlerTest
         _mockRepositoryWrapper.Setup(r => r.StreetcodeRepository.Create(entity));
         _mockRepositoryWrapper.Setup(r => r.SaveChangesAsync())
             .ReturnsAsync(1);
+        _mockRepositoryWrapper.Setup(r => r.BeginTransaction())
+            .Returns(new TransactionScope(TransactionScopeOption.Suppress));
     }
 
-    private void SetupImagesForSuccess(StreetcodeCreateCommand request)
+    private void SetupImagesForSuccess()
     {
-        _mockRepositoryWrapper.Setup(r => r.SaveChangesAsync())
-            .ReturnsAsync(1);
+        _mockRepositoryWrapper.Setup(r => r.StreetcodeImageRepository.CreateRangeAsync(It.IsAny<IEnumerable<StreetcodeImage>>()))
+            .Returns(Task.CompletedTask);
     }
 
-    private void SetupTagsForSuccess(StreetcodeCreateCommand request)
+    private void SetupTagsForSuccess()
     {
-        _mockRepositoryWrapper.Setup(r => r.SaveChangesAsync())
-            .ReturnsAsync(1);
+        _mockRepositoryWrapper.Setup(r => r.StreetcodeTagIndexRepository.CreateRangeAsync(It.IsAny<IEnumerable<StreetcodeTagIndex>>()))
+            .Returns(Task.CompletedTask);
+        _mockRepositoryWrapper.Setup(r => r.TagRepository.GetFirstOrDefaultAsync(
+                It.IsAny<System.Linq.Expressions.Expression<Func<Tag, bool>>>(),
+                It.IsAny<Func<IQueryable<Tag>, IIncludableQueryable<Tag, object>>>()))
+            .ReturnsAsync((Tag?)null);
+        _mockMapper.Setup(m => m.Map<Tag>(It.IsAny<StreetcodeTagDTO>()))
+            .Returns(new Tag { Id = 1, Title = "Test Tag" });
     }
 
-    private void SetupImagesDetailsForSuccess(StreetcodeCreateCommand request)
+    private void SetupImagesDetailsForSuccess()
     {
-        _mockRepositoryWrapper.Setup(r => r.SaveChangesAsync())
-            .ReturnsAsync(1);
+        _mockRepositoryWrapper.Setup(r => r.ImageDetailsRepository.CreateRangeAsync(It.IsAny<IEnumerable<ImageDetails>>()))
+            .Returns(Task.CompletedTask);
+        _mockMapper.Setup(m => m.Map<IEnumerable<ImageDetails>>(It.IsAny<IEnumerable<ImageDetailsDto>>()))
+            .Returns(new List<ImageDetails> { new ImageDetails { Id = 1, ImageId = 1 } });
+    }
+
+    private void SetupArtCreationForSuccess(List<Art> artEntities, List<Image> images)
+    {
+        // Setup image existence check
+        _mockRepositoryWrapper.Setup(r => r.ImageRepository.GetAllAsync(
+                It.IsAny<System.Linq.Expressions.Expression<Func<Image, bool>>>(),
+                It.IsAny<Func<IQueryable<Image>, IIncludableQueryable<Image, object>>>()))
+            .ReturnsAsync(images);
+
+        _mockMapper.Setup(m => m.Map<List<Art>>(It.IsAny<List<ArtCreateUpdateDTO>>()))
+            .Returns(artEntities);
+
+        _mockRepositoryWrapper.Setup(r => r.ArtRepository.CreateRangeAsync(It.IsAny<IEnumerable<Art>>()))
+            .Callback<IEnumerable<Art>>(arts =>
+            {
+                // Simulate setting IDs for created entities
+                var artList = arts.ToList();
+                for (int i = 0; i < artList.Count; i++)
+                {
+                    artList[i].Id = i + 1;
+                }
+            })
+            .Returns(Task.CompletedTask);
+    }
+
+    private void SetupArtSlideCreationForSuccess()
+    {
+        var artSlideEntities = new List<StreetcodeArtSlide>
+        {
+            new StreetcodeArtSlide { Id = 1, Index = 0, StreetcodeId = 1 },
+            new StreetcodeArtSlide { Id = 2, Index = 1, StreetcodeId = 1 }
+        };
+
+        _mockMapper.Setup(m => m.Map<List<StreetcodeArtSlide>>(It.IsAny<List<StreetcodeArtSlideCreateUpdateDTO>>()))
+            .Returns(artSlideEntities);
+
+        _mockRepositoryWrapper.Setup(r => r.StreetcodeArtSlideRepository.CreateRangeAsync(It.IsAny<IEnumerable<StreetcodeArtSlide>>()))
+            .Callback<IEnumerable<StreetcodeArtSlide>>(slides =>
+            {
+                // Simulate setting IDs for created entities
+                var slideList = slides.ToList();
+                for (int i = 0; i < slideList.Count; i++)
+                {
+                    slideList[i].Id = i + 1;
+                }
+            })
+            .Returns(Task.CompletedTask);
+
+        // Setup art existence check for slides
+        _mockRepositoryWrapper.Setup(r => r.ArtRepository.GetFirstOrDefaultAsync(
+                It.IsAny<System.Linq.Expressions.Expression<Func<Art, bool>>>(),
+                It.IsAny<Func<IQueryable<Art>, IIncludableQueryable<Art, object>>>()))
+            .ReturnsAsync(new Art { Id = 1 });
+
+        _mockMapper.Setup(m => m.Map<StreetcodeArt>(It.IsAny<StreetcodeArtCreateUpdateDTO>()))
+            .Returns(new StreetcodeArt());
+
+        _mockRepositoryWrapper.Setup(r => r.StreetcodeArtRepository.CreateRangeAsync(It.IsAny<IEnumerable<StreetcodeArt>>()))
+            .Returns(Task.CompletedTask);
     }
 
     private void VerifySuccessCalls(StreetcodeCreateCommand request, StreetcodeContent entity)
@@ -258,5 +747,12 @@ public class StreetcodeCreateHandlerTest
         _mockRepositoryWrapper.Verify(r => r.SaveChangesAsync(), Times.AtLeast(2));
         _mockMapper.Verify(m => m.Map<StreetcodeDTO>(entity), Times.Once);
         _mockLogger.Verify(l => l.LogInformation(It.IsAny<string>()), Times.Once);
+    }
+
+    private void VerifyArtGalleryCreationCalls()
+    {
+        _mockRepositoryWrapper.Verify(r => r.ArtRepository.CreateRangeAsync(It.IsAny<IEnumerable<Art>>()), Times.Once);
+        _mockRepositoryWrapper.Verify(r => r.StreetcodeArtSlideRepository.CreateRangeAsync(It.IsAny<IEnumerable<StreetcodeArtSlide>>()), Times.Once);
+        _mockRepositoryWrapper.Verify(r => r.StreetcodeArtRepository.CreateRangeAsync(It.IsAny<IEnumerable<StreetcodeArt>>()), Times.Once);
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/BLL/MediatR/StreetCode/Streetcode/Update/UpdateStreetcodeTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/MediatR/StreetCode/Streetcode/Update/UpdateStreetcodeTests.cs
@@ -1,20 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Linq.Expressions;
 using System.Transactions;
 using AutoMapper;
 using Microsoft.EntityFrameworkCore.Query;
 using Moq;
+using Streetcode.BLL.DTO.ArtGallery;
+using Streetcode.BLL.DTO.Media.Art;
 using Streetcode.BLL.DTO.Streetcode.Update;
+using Streetcode.BLL.Enums;
 using Streetcode.BLL.Interfaces.Logging;
 using Streetcode.BLL.MediatR.Streetcode.Streetcode.Update;
-using Streetcode.BLL.MediatR.Streetcode.Text.GetById;
 using Streetcode.DAL.Entities.AdditionalContent;
 using Streetcode.DAL.Entities.Media.Images;
 using Streetcode.DAL.Entities.Streetcode;
+using Streetcode.DAL.Enums;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 using Xunit;
 
@@ -26,6 +24,7 @@ namespace Streetcode.XUnitTest.BLL.MediatR.StreetCode.Streetcode.Update
         private readonly Mock<IMapper> _mapperMock;
         private readonly Mock<ILoggerService> _loggerServiceMock;
         private readonly UpdateStreetcodeHandler _handler;
+
         public UpdateStreetcodeTests()
         {
             _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
@@ -50,22 +49,23 @@ namespace Streetcode.XUnitTest.BLL.MediatR.StreetCode.Streetcode.Update
 
             _repositoryWrapperMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
 
-            // Мок для маппера
             _mapperMock.Setup(m => m.Map(It.IsAny<StreetcodeUpdateDTO>(), It.IsAny<StreetcodeContent>()))
                 .Verifiable();
 
             using var realTransactionScope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
             _repositoryWrapperMock.Setup(r => r.BeginTransaction()).Returns(realTransactionScope);
 
-            SetupAdditionalMocks();
+            SetupBasicMocks();
 
+            // Act
             var result = await _handler.Handle(request, CancellationToken.None);
 
+            // Assert
             Assert.True(result.IsSuccess, $"Result should be successful but failed with: {string.Join(", ", result.Errors.Select(e => e.Message))}");
             Assert.Equal(10, result.Value);
             Assert.True(entity.UpdatedAt > DateTime.MinValue);
 
-            _repositoryWrapperMock.Verify(r => r.SaveChangesAsync(), Times.Once);
+            _repositoryWrapperMock.Verify(r => r.SaveChangesAsync(), Times.AtLeast(1));
             _loggerServiceMock.Verify(l => l.LogInformation(It.IsAny<string>()), Times.Once);
             _repositoryWrapperMock.Verify(r => r.BeginTransaction(), Times.Once);
             _mapperMock.Verify(m => m.Map(It.IsAny<StreetcodeUpdateDTO>(), It.IsAny<StreetcodeContent>()), Times.Once);
@@ -74,6 +74,7 @@ namespace Streetcode.XUnitTest.BLL.MediatR.StreetCode.Streetcode.Update
         [Fact]
         public async Task Handle_Should_ReturnFail_WhenEntityNotFound()
         {
+            // Arrange
             var request = new UpdateStreetcodeCommand(new StreetcodeUpdateDTO { Id = 1 });
 
             _repositoryWrapperMock.Setup(r => r.StreetcodeRepository.GetFirstOrDefaultAsync(
@@ -81,8 +82,10 @@ namespace Streetcode.XUnitTest.BLL.MediatR.StreetCode.Streetcode.Update
                It.IsAny<Func<IQueryable<StreetcodeContent>, IIncludableQueryable<StreetcodeContent, object>>>()))
                 .ReturnsAsync((StreetcodeContent)null!);
 
+            // Act
             var result = await _handler.Handle(request, CancellationToken.None);
 
+            // Assert
             Assert.True(result.IsFailed);
             _loggerServiceMock.Verify(l => l.LogError(request, It.IsAny<string>()), Times.Once);
         }
@@ -90,8 +93,8 @@ namespace Streetcode.XUnitTest.BLL.MediatR.StreetCode.Streetcode.Update
         [Fact]
         public async Task Handle_ShouldReturnFail_WhenSaveChangesFails()
         {
+            // Arrange
             var entity = new StreetcodeContent { Id = 1 };
-
             var request = new UpdateStreetcodeCommand(new StreetcodeUpdateDTO { Id = 1 });
 
             _repositoryWrapperMock.Setup(r => r.StreetcodeRepository.GetFirstOrDefaultAsync(
@@ -100,10 +103,14 @@ namespace Streetcode.XUnitTest.BLL.MediatR.StreetCode.Streetcode.Update
                 .ReturnsAsync(entity);
 
             _repositoryWrapperMock.Setup(r => r.SaveChangesAsync())
-                .ReturnsAsync(0);
+                .ReturnsAsync(-1);
 
+            SetupBasicMocks();
+
+            // Act
             var result = await _handler.Handle(request, CancellationToken.None);
 
+            // Assert
             Assert.True(result.IsFailed);
             _loggerServiceMock.Verify(l => l.LogError(request, It.IsAny<string>()), Times.Once);
         }
@@ -111,6 +118,7 @@ namespace Streetcode.XUnitTest.BLL.MediatR.StreetCode.Streetcode.Update
         [Fact]
         public async Task Handle_ShouldReturnFail_WhenThrowException()
         {
+            // Arrange
             var request = new UpdateStreetcodeCommand(new StreetcodeUpdateDTO { Id = 1 });
 
             _repositoryWrapperMock.Setup(r => r.StreetcodeRepository.GetFirstOrDefaultAsync(
@@ -118,15 +126,248 @@ namespace Streetcode.XUnitTest.BLL.MediatR.StreetCode.Streetcode.Update
                 It.IsAny<Func<IQueryable<StreetcodeContent>, IIncludableQueryable<StreetcodeContent, object>>>()))
                 .ThrowsAsync(new Exception("DB error"));
 
+            // Act
             var result = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
             Assert.True(result.IsFailed);
             Assert.Contains("DB error", result.Errors[0].Message);
             _loggerServiceMock.Verify(l => l.LogError(request, "DB error"), Times.Once);
         }
 
-        private void SetupAdditionalMocks()
+        [Fact]
+        public async Task Handle_Should_UpdateArtGallery_WhenValidArtsAndSlidesProvided()
         {
-            // Моки для методів оновлення тегів та зображень
+            // Arrange
+            var entity = new StreetcodeContent { Id = 1 };
+            var requestDto = CreateRequestWithArtGallery();
+            var request = new UpdateStreetcodeCommand(requestDto);
+
+            SetupSuccessfulUpdate(entity);
+            SetupArtGalleryMocks();
+
+            // Act
+            var result = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            VerifyArtGalleryUpdateCalls();
+        }
+
+        [Fact]
+        public async Task Handle_Should_SkipArtGalleryUpdate_WhenNoArtsOrSlidesProvided()
+        {
+            // Arrange
+            var entity = new StreetcodeContent { Id = 1 };
+            var requestDto = new StreetcodeUpdateDTO { Id = 1 };
+            var request = new UpdateStreetcodeCommand(requestDto);
+
+            SetupSuccessfulUpdate(entity);
+            SetupBasicMocks();
+
+            // Act
+            var result = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            VerifyArtRepositoriesNotCalled();
+        }
+
+        [Fact]
+        public async Task Handle_Should_CreateNewArts_WhenArtsWithCreatedModelState()
+        {
+            // Arrange
+            var entity = new StreetcodeContent { Id = 1 };
+            var requestDto = CreateRequestWithNewArts();
+            var request = new UpdateStreetcodeCommand(requestDto);
+
+            SetupSuccessfulUpdate(entity);
+            SetupArtGalleryMocks();
+
+            // Act
+            var result = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            _repositoryWrapperMock.Verify(r => r.ArtRepository.CreateRangeAsync(It.IsAny<IEnumerable<Art>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_Should_UpdateExistingArts_WhenArtsWithUpdatedModelState()
+        {
+            // Arrange
+            var entity = new StreetcodeContent { Id = 1 };
+            var requestDto = CreateRequestWithUpdatedArts();
+            var request = new UpdateStreetcodeCommand(requestDto);
+
+            SetupSuccessfulUpdate(entity);
+            SetupArtGalleryMocks();
+
+            // Act
+            var result = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            _repositoryWrapperMock.Verify(r => r.ArtRepository.UpdateRange(It.IsAny<IEnumerable<Art>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_Should_DeleteArts_WhenArtsWithDeletedModelState()
+        {
+            // Arrange
+            var entity = new StreetcodeContent { Id = 1 };
+            var requestDto = CreateRequestWithDeletedArts();
+            var request = new UpdateStreetcodeCommand(requestDto);
+
+            SetupSuccessfulUpdate(entity);
+            SetupArtGalleryMocks();
+
+            // Act
+            var result = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            _repositoryWrapperMock.Verify(r => r.ArtRepository.DeleteRange(It.IsAny<IEnumerable<Art>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_Should_CreateNewSlides_WhenSlidesWithCreatedModelState()
+        {
+            // Arrange
+            var entity = new StreetcodeContent { Id = 1 };
+            var requestDto = CreateRequestWithNewSlides();
+            var request = new UpdateStreetcodeCommand(requestDto);
+
+            SetupSuccessfulUpdate(entity);
+            SetupArtGalleryMocks();
+
+            // Act
+            var result = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            _repositoryWrapperMock.Verify(r => r.StreetcodeArtSlideRepository.CreateRangeAsync(It.IsAny<IEnumerable<StreetcodeArtSlide>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_Should_UpdateExistingSlides_WhenSlidesWithUpdatedModelState()
+        {
+            // Arrange
+            var entity = new StreetcodeContent { Id = 1 };
+            var requestDto = CreateRequestWithUpdatedSlides();
+            var request = new UpdateStreetcodeCommand(requestDto);
+
+            SetupSuccessfulUpdate(entity);
+            SetupArtGalleryMocks();
+
+            // Act
+            var result = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            _repositoryWrapperMock.Verify(r => r.StreetcodeArtSlideRepository.UpdateRange(It.IsAny<IEnumerable<StreetcodeArtSlide>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_Should_DeleteSlides_WhenSlidesWithDeletedModelState()
+        {
+            // Arrange
+            var entity = new StreetcodeContent { Id = 1 };
+            var requestDto = CreateRequestWithDeletedSlides();
+            var request = new UpdateStreetcodeCommand(requestDto);
+
+            SetupSuccessfulUpdate(entity);
+            SetupArtGalleryMocks();
+
+            // Act
+            var result = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            _repositoryWrapperMock.Verify(r => r.StreetcodeArtSlideRepository.DeleteRange(It.IsAny<IEnumerable<StreetcodeArtSlide>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_Should_RebuildStreetcodeArts_WhenSlidesProvided()
+        {
+            // Arrange
+            var entity = new StreetcodeContent { Id = 1 };
+            var requestDto = CreateRequestWithArtGallery();
+            var request = new UpdateStreetcodeCommand(requestDto);
+
+            SetupSuccessfulUpdate(entity);
+            SetupArtGalleryMocks();
+
+            // Mock existing StreetcodeArts
+            var existingStreetcodeArts = new List<StreetcodeArt>
+            {
+                new StreetcodeArt { Id = 1, StreetcodeId = 1, ArtId = 1, StreetcodeArtSlideId = 1 }
+            };
+            _repositoryWrapperMock.Setup(r => r.StreetcodeArtRepository.GetAllAsync(
+                It.IsAny<Expression<Func<StreetcodeArt, bool>>>(),
+                It.IsAny<Func<IQueryable<StreetcodeArt>, IIncludableQueryable<StreetcodeArt, object>>>()))
+                .ReturnsAsync(existingStreetcodeArts);
+
+            // Act
+            var result = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            _repositoryWrapperMock.Verify(r => r.StreetcodeArtRepository.DeleteRange(existingStreetcodeArts), Times.Once);
+            _repositoryWrapperMock.Verify(r => r.StreetcodeArtRepository.CreateRangeAsync(It.IsAny<IEnumerable<StreetcodeArt>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Handle_Should_ThrowException_WhenImageDoesNotExistForArt()
+        {
+            // Arrange
+            var entity = new StreetcodeContent { Id = 1 };
+            var requestDto = CreateRequestWithInvalidImageId();
+            var request = new UpdateStreetcodeCommand(requestDto);
+
+            SetupSuccessfulUpdate(entity);
+            SetupBasicMocks();
+
+            // Setup empty image list (image doesn't exist)
+            _repositoryWrapperMock.Setup(r => r.ImageRepository.GetAllAsync(
+                It.IsAny<Expression<Func<Image, bool>>>(),
+                It.IsAny<Func<IQueryable<Image>, IIncludableQueryable<Image, object>>>()))
+                .ReturnsAsync(new List<Image>());
+
+            // Act & Assert
+            var result = await _handler.Handle(request, CancellationToken.None);
+            Assert.True(result.IsFailed);
+            Assert.Contains("Image with ID 999 does not exist", result.Errors[0].Message);
+        }
+
+        [Fact]
+        public async Task Handle_Should_ThrowException_WhenArtDoesNotExistForStreetcodeArt()
+        {
+            // Arrange
+            var entity = new StreetcodeContent { Id = 1 };
+            var requestDto = CreateRequestWithInvalidArtId();
+            var request = new UpdateStreetcodeCommand(requestDto);
+
+            SetupSuccessfulUpdate(entity);
+            SetupArtGalleryMocks();
+
+            // Setup art repository to return null for non-existent art
+            _repositoryWrapperMock.Setup(r => r.ArtRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<Art, bool>>>(),
+                It.IsAny<Func<IQueryable<Art>, IIncludableQueryable<Art, object>>>()))
+                .ReturnsAsync((Art)null!);
+
+            // Act
+            var result = await _handler.Handle(request, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.IsFailed);
+            Assert.Contains("Art with ID 999 does not exist", result.Errors[0].Message);
+        }
+
+        private void SetupBasicMocks()
+        {
+            // Setup basic repository mocks for tags and images
             _repositoryWrapperMock.Setup(r => r.StreetcodeTagIndexRepository.CreateRangeAsync(It.IsAny<IEnumerable<StreetcodeTagIndex>>()))
                 .Returns(Task.CompletedTask);
             _repositoryWrapperMock.Setup(r => r.StreetcodeTagIndexRepository.DeleteRange(It.IsAny<IEnumerable<StreetcodeTagIndex>>()))
@@ -137,6 +378,248 @@ namespace Streetcode.XUnitTest.BLL.MediatR.StreetCode.Streetcode.Update
                 .Verifiable();
             _repositoryWrapperMock.Setup(r => r.StreetcodeImageRepository.CreateRangeAsync(It.IsAny<IEnumerable<StreetcodeImage>>()))
                 .Returns(Task.CompletedTask);
+
+            // Setup transaction
+            _repositoryWrapperMock.Setup(r => r.BeginTransaction()).Returns(new TransactionScope(TransactionScopeOption.Suppress));
+        }
+
+        private void SetupArtGalleryMocks()
+        {
+            SetupBasicMocks();
+
+            // Setup Art repository mocks
+            _repositoryWrapperMock.Setup(r => r.ArtRepository.CreateRangeAsync(It.IsAny<IEnumerable<Art>>()))
+                .Returns(Task.CompletedTask);
+            _repositoryWrapperMock.Setup(r => r.ArtRepository.UpdateRange(It.IsAny<IEnumerable<Art>>()))
+                .Verifiable();
+            _repositoryWrapperMock.Setup(r => r.ArtRepository.DeleteRange(It.IsAny<IEnumerable<Art>>()))
+                .Verifiable();
+
+            // Setup StreetcodeArtSlide repository mocks
+            _repositoryWrapperMock.Setup(r => r.StreetcodeArtSlideRepository.CreateRangeAsync(It.IsAny<IEnumerable<StreetcodeArtSlide>>()))
+                .Returns(Task.CompletedTask);
+            _repositoryWrapperMock.Setup(r => r.StreetcodeArtSlideRepository.UpdateRange(It.IsAny<IEnumerable<StreetcodeArtSlide>>()))
+                .Verifiable();
+            _repositoryWrapperMock.Setup(r => r.StreetcodeArtSlideRepository.DeleteRange(It.IsAny<IEnumerable<StreetcodeArtSlide>>()))
+                .Verifiable();
+
+            // Setup StreetcodeArt repository mocks
+            _repositoryWrapperMock.Setup(r => r.StreetcodeArtRepository.CreateRangeAsync(It.IsAny<IEnumerable<StreetcodeArt>>()))
+                .Returns(Task.CompletedTask);
+            _repositoryWrapperMock.Setup(r => r.StreetcodeArtRepository.DeleteRange(It.IsAny<IEnumerable<StreetcodeArt>>()))
+                .Verifiable();
+            _repositoryWrapperMock.Setup(r => r.StreetcodeArtRepository.GetAllAsync(
+                It.IsAny<Expression<Func<StreetcodeArt, bool>>>(),
+                It.IsAny<Func<IQueryable<StreetcodeArt>, IIncludableQueryable<StreetcodeArt, object>>>()))
+                .ReturnsAsync(new List<StreetcodeArt>());
+
+            // Setup Image repository for validation
+            _repositoryWrapperMock.Setup(r => r.ImageRepository.GetAllAsync(
+                It.IsAny<Expression<Func<Image, bool>>>(),
+                It.IsAny<Func<IQueryable<Image>, IIncludableQueryable<Image, object>>>()))
+                .ReturnsAsync(new List<Image> { new Image { Id = 1 }, new Image { Id = 2 } });
+
+            // Setup Art repository for validation
+            _repositoryWrapperMock.Setup(r => r.ArtRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<Art, bool>>>(),
+                It.IsAny<Func<IQueryable<Art>, IIncludableQueryable<Art, object>>>()))
+                .ReturnsAsync(new Art { Id = 1 });
+
+            // Setup created slide lookup
+            _repositoryWrapperMock.Setup(r => r.StreetcodeArtSlideRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<StreetcodeArtSlide, bool>>>(),
+                It.IsAny<Func<IQueryable<StreetcodeArtSlide>, IIncludableQueryable<StreetcodeArtSlide, object>>>()))
+                .ReturnsAsync(new StreetcodeArtSlide { Id = 1, StreetcodeId = 1, Index = 0, Template = GallerySlideTemplate.OneToTwo });
+
+            // Setup mapper for art gallery entities
+            _mapperMock.Setup(m => m.Map<IEnumerable<Art>>(It.IsAny<IEnumerable<ArtCreateUpdateDTO>>()))
+                .Returns(new List<Art> { new Art { Id = 1, Title = "Test Art" } });
+            _mapperMock.Setup(m => m.Map<IEnumerable<StreetcodeArtSlide>>(It.IsAny<IEnumerable<StreetcodeArtSlideCreateUpdateDTO>>()))
+                .Returns(new List<StreetcodeArtSlide> { new StreetcodeArtSlide { Id = 1, Index = 0, Template = GallerySlideTemplate.OneToTwo } });
+        }
+
+        private void SetupSuccessfulUpdate(StreetcodeContent entity)
+        {
+            _repositoryWrapperMock.Setup(r => r.StreetcodeRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<StreetcodeContent, bool>>>(),
+                It.IsAny<Func<IQueryable<StreetcodeContent>, IIncludableQueryable<StreetcodeContent, object>>>()))
+                .ReturnsAsync(entity);
+
+            _repositoryWrapperMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
+
+            _mapperMock.Setup(m => m.Map(It.IsAny<StreetcodeUpdateDTO>(), It.IsAny<StreetcodeContent>()))
+                .Verifiable();
+        }
+
+        private StreetcodeUpdateDTO CreateRequestWithArtGallery()
+        {
+            return new StreetcodeUpdateDTO
+            {
+                Id = 1,
+                Arts = new List<ArtCreateUpdateDTO>
+                {
+                    new ArtCreateUpdateDTO { Id = 1, Title = "Art 1", Description = "Desc 1", ImageId = 1, ModelState = ModelState.Created }
+                },
+                StreetcodeArtSlides = new List<StreetcodeArtSlideCreateUpdateDTO>
+                {
+                    new StreetcodeArtSlideCreateUpdateDTO
+                    {
+                        Id = 1,
+                        Index = 0,
+                        Template = GallerySlideTemplate.OneToTwo,
+                        ModelState = ModelState.Created,
+                        StreetcodeArts = new List<StreetcodeArtCreateUpdateDTO>
+                        {
+                            new StreetcodeArtCreateUpdateDTO { Index = 0, ArtId = 1 }
+                        }
+                    }
+                }
+            };
+        }
+
+        private StreetcodeUpdateDTO CreateRequestWithNewArts()
+        {
+            return new StreetcodeUpdateDTO
+            {
+                Id = 1,
+                Arts = new List<ArtCreateUpdateDTO>
+                {
+                    new ArtCreateUpdateDTO { Id = 1, Title = "New Art", Description = "New Desc", ImageId = 1, ModelState = ModelState.Created }
+                }
+            };
+        }
+
+        private StreetcodeUpdateDTO CreateRequestWithUpdatedArts()
+        {
+            return new StreetcodeUpdateDTO
+            {
+                Id = 1,
+                Arts = new List<ArtCreateUpdateDTO>
+                {
+                    new ArtCreateUpdateDTO { Id = 1, Title = "Updated Art", Description = "Updated Desc", ImageId = 1, ModelState = ModelState.Updated }
+                }
+            };
+        }
+
+        private StreetcodeUpdateDTO CreateRequestWithDeletedArts()
+        {
+            return new StreetcodeUpdateDTO
+            {
+                Id = 1,
+                Arts = new List<ArtCreateUpdateDTO>
+                {
+                    new ArtCreateUpdateDTO { Id = 1, Title = "Art to Delete", Description = "Delete Desc", ImageId = 1, ModelState = ModelState.Deleted }
+                }
+            };
+        }
+
+        private StreetcodeUpdateDTO CreateRequestWithNewSlides()
+        {
+            return new StreetcodeUpdateDTO
+            {
+                Id = 1,
+                StreetcodeArtSlides = new List<StreetcodeArtSlideCreateUpdateDTO>
+                {
+                    new StreetcodeArtSlideCreateUpdateDTO
+                    {
+                        Id = 1,
+                        Index = 0,
+                        Template = GallerySlideTemplate.OneToTwo,
+                        ModelState = ModelState.Created,
+                        StreetcodeArts = new List<StreetcodeArtCreateUpdateDTO>()
+                    }
+                }
+            };
+        }
+
+        private StreetcodeUpdateDTO CreateRequestWithUpdatedSlides()
+        {
+            return new StreetcodeUpdateDTO
+            {
+                Id = 1,
+                StreetcodeArtSlides = new List<StreetcodeArtSlideCreateUpdateDTO>
+                {
+                    new StreetcodeArtSlideCreateUpdateDTO
+                    {
+                        Id = 1,
+                        Index = 0,
+                        Template = GallerySlideTemplate.OneAndTwo,
+                        ModelState = ModelState.Updated,
+                        StreetcodeArts = new List<StreetcodeArtCreateUpdateDTO>()
+                    }
+                }
+            };
+        }
+
+        private StreetcodeUpdateDTO CreateRequestWithDeletedSlides()
+        {
+            return new StreetcodeUpdateDTO
+            {
+                Id = 1,
+                StreetcodeArtSlides = new List<StreetcodeArtSlideCreateUpdateDTO>
+                {
+                    new StreetcodeArtSlideCreateUpdateDTO
+                    {
+                        Id = 1,
+                        Index = 0,
+                        Template = GallerySlideTemplate.OneToTwo,
+                        ModelState = ModelState.Deleted,
+                        StreetcodeArts = new List<StreetcodeArtCreateUpdateDTO>()
+                    }
+                }
+            };
+        }
+
+        private StreetcodeUpdateDTO CreateRequestWithInvalidImageId()
+        {
+            return new StreetcodeUpdateDTO
+            {
+                Id = 1,
+                Arts = new List<ArtCreateUpdateDTO>
+                {
+                    new ArtCreateUpdateDTO { Id = 1, Title = "Art with invalid image", Description = "Desc", ImageId = 999, ModelState = ModelState.Created }
+                }
+            };
+        }
+
+        private StreetcodeUpdateDTO CreateRequestWithInvalidArtId()
+        {
+            return new StreetcodeUpdateDTO
+            {
+                Id = 1,
+                StreetcodeArtSlides = new List<StreetcodeArtSlideCreateUpdateDTO>
+                {
+                    new StreetcodeArtSlideCreateUpdateDTO
+                    {
+                        Id = 1,
+                        Index = 0,
+                        Template = GallerySlideTemplate.OneToTwo,
+                        ModelState = ModelState.Created,
+                        StreetcodeArts = new List<StreetcodeArtCreateUpdateDTO>
+                        {
+                            new StreetcodeArtCreateUpdateDTO { Index = 0, ArtId = 999 }
+                        }
+                    }
+                }
+            };
+        }
+
+        private void VerifyArtGalleryUpdateCalls()
+        {
+            _repositoryWrapperMock.Verify(r => r.ArtRepository.CreateRangeAsync(It.IsAny<IEnumerable<Art>>()), Times.Once);
+            _repositoryWrapperMock.Verify(r => r.StreetcodeArtSlideRepository.CreateRangeAsync(It.IsAny<IEnumerable<StreetcodeArtSlide>>()), Times.Once);
+            _repositoryWrapperMock.Verify(r => r.StreetcodeArtRepository.CreateRangeAsync(It.IsAny<IEnumerable<StreetcodeArt>>()), Times.Once);
+        }
+
+        private void VerifyArtRepositoriesNotCalled()
+        {
+            _repositoryWrapperMock.Verify(r => r.ArtRepository.CreateRangeAsync(It.IsAny<IEnumerable<Art>>()), Times.Never);
+            _repositoryWrapperMock.Verify(r => r.ArtRepository.UpdateRange(It.IsAny<IEnumerable<Art>>()), Times.Never);
+            _repositoryWrapperMock.Verify(r => r.ArtRepository.DeleteRange(It.IsAny<IEnumerable<Art>>()), Times.Never);
+            _repositoryWrapperMock.Verify(r => r.StreetcodeArtSlideRepository.CreateRangeAsync(It.IsAny<IEnumerable<StreetcodeArtSlide>>()), Times.Never);
+            _repositoryWrapperMock.Verify(r => r.StreetcodeArtSlideRepository.UpdateRange(It.IsAny<IEnumerable<StreetcodeArtSlide>>()), Times.Never);
+            _repositoryWrapperMock.Verify(r => r.StreetcodeArtSlideRepository.DeleteRange(It.IsAny<IEnumerable<StreetcodeArtSlide>>()), Times.Never);
+            _repositoryWrapperMock.Verify(r => r.StreetcodeArtRepository.CreateRangeAsync(It.IsAny<IEnumerable<StreetcodeArt>>()), Times.Never);
         }
     }
 }


### PR DESCRIPTION
dev

## Code reviewers

- [ ] @weazy12 
- [ ] @Markian-Grybok 

## Summary of issue

Integrate Art Gallery CRUD into Streetcode MediatR Handlers and Endpoints
[#116](https://github.com/project-studying-dotnet/Streetcode-Server-August-2025/issues/116)
This is a sub-issue of #104 

## Summary of change

Closes #116 

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added art gallery management during create and update, including arts, slides, and their relationships.
  * Streetcode creation now supports setting Type and Status.
* Improvements
  * Enhanced validation with clear errors for missing/empty image details and tags.
  * More reliable save flow with better error handling during multi-step operations.
* Tests
  * Substantially expanded test coverage for create/update flows, including art gallery lifecycle (create, update, delete, rebuild) and validation/error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->