### PR TITLE
Fix/125/fix inconsistent fluent validation integration

### DIFF
--- a/Streetcode/Streetcode.BLL/MediatR/Sources/SourceLinkCategory/Create/CreateSourceLinkCategoryCommand.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Sources/SourceLinkCategory/Create/CreateSourceLinkCategoryCommand.cs
@@ -1,14 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using FluentResults;
+﻿using FluentResults;
 using MediatR;
-using Microsoft.AspNetCore.Http;
 using Streetcode.BLL.DTO.Sources;
 
 namespace Streetcode.BLL.MediatR.Sources.SourceLinkCategory.Create
 {
-    public record CreateSourceLinkCategoryCommand(SourceLinkCategoryCreateDTO sourceLinkCategoryCreateDTO) : IRequest<Result<SourceLinkCategoryDTO>>;
+    public record CreateSourceLinkCategoryCommand(SourceLinkCategoryCreateDTO SourceLinkCategoryCreateDTO)
+        : IRequest<Result<SourceLinkCategoryDTO>>;
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Sources/SourceLinkCategory/Create/CreateSourceLinkCategoryHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Sources/SourceLinkCategory/Create/CreateSourceLinkCategoryHandler.cs
@@ -27,7 +27,7 @@ namespace Streetcode.BLL.MediatR.Sources.SourceLinkCategory.Create
 
         public async Task<Result<SourceLinkCategoryDTO>> Handle(CreateSourceLinkCategoryCommand request, CancellationToken cancellationToken)
         {
-            var entity = _mapper.Map<DAL.Entities.Sources.SourceLinkCategory>(request.sourceLinkCategoryCreateDTO);
+            var entity = _mapper.Map<DAL.Entities.Sources.SourceLinkCategory>(request.SourceLinkCategoryCreateDTO);
 
             var existing = await _repositoryWrapper.SourceCategoryRepository
             .GetFirstOrDefaultAsync(c => c.Title == entity.Title

--- a/Streetcode/Streetcode.BLL/MediatR/Sources/SourceLinkCategory/Update/UpdateSourceLinkCategoryCommand.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Sources/SourceLinkCategory/Update/UpdateSourceLinkCategoryCommand.cs
@@ -1,14 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using FluentResults;
+﻿using FluentResults;
 using MediatR;
 using Streetcode.BLL.DTO.Sources;
 
 namespace Streetcode.BLL.MediatR.Sources.SourceLinkCategory.Update
 {
-    public record UpdateSourceLinkCategoryCommand(SourceLinkCategoryUpdateDTO sourceLinkCategoryUpdate)
+    public record UpdateSourceLinkCategoryCommand(SourceLinkCategoryUpdateDTO SourceLinkCategoryUpdate)
     : IRequest<Result<SourceLinkCategoryDTO>>;
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Sources/SourceLinkCategory/Update/UpdateSourceLinkCategoryHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Sources/SourceLinkCategory/Update/UpdateSourceLinkCategoryHandler.cs
@@ -29,14 +29,14 @@ namespace Streetcode.BLL.MediatR.Sources.SourceLinkCategory.Update
         public async Task<Result<SourceLinkCategoryDTO>> Handle(UpdateSourceLinkCategoryCommand request, CancellationToken cancellationToken)
         {
             var categoryEntity = await _repositoryWrapper.SourceCategoryRepository
-            .GetFirstOrDefaultAsync(c => c.Id == request.sourceLinkCategoryUpdate.Id);
+            .GetFirstOrDefaultAsync(c => c.Id == request.SourceLinkCategoryUpdate.Id);
 
             if (categoryEntity == null)
             {
                 return Result.Fail("Category not found.");
             }
 
-            _mapper.Map(request.sourceLinkCategoryUpdate, categoryEntity);
+            _mapper.Map(request.SourceLinkCategoryUpdate, categoryEntity);
 
             var existing = await _repositoryWrapper.SourceCategoryRepository
             .GetFirstOrDefaultAsync(c => (c.Title == categoryEntity.Title || c.ImageId == categoryEntity.ImageId)

--- a/Streetcode/Streetcode.BLL/MediatR/Sources/StreetcodeCategoryContent/Create/CreateStreetcodeCategoryContentCommand.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Sources/StreetcodeCategoryContent/Create/CreateStreetcodeCategoryContentCommand.cs
@@ -1,13 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using FluentResults;
+﻿using FluentResults;
 using MediatR;
 using Streetcode.BLL.DTO.Sources;
 
 namespace Streetcode.BLL.MediatR.Sources.StreetcodeCategoryContent.Create
 {
-    public record CreateStreetcodeCategoryContentCommand(CategoryContentCreateDTO createCategoryContentDto) : IRequest<Result<StreetcodeCategoryContentDTO>>;
+    public record CreateStreetcodeCategoryContentCommand(CategoryContentCreateDTO CreateCategoryContentDto)
+        : IRequest<Result<StreetcodeCategoryContentDTO>>;
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Sources/StreetcodeCategoryContent/Create/CreateStreetcodeCategoryHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Sources/StreetcodeCategoryContent/Create/CreateStreetcodeCategoryHandler.cs
@@ -28,7 +28,7 @@ namespace Streetcode.BLL.MediatR.Sources.StreetcodeCategoryContent.Create
 
         public async Task<Result<StreetcodeCategoryContentDTO>> Handle(CreateStreetcodeCategoryContentCommand request, CancellationToken cancellationToken)
         {
-            var streetcodeCategoryContentEntity = _mapper.Map<DAL.Entities.Sources.StreetcodeCategoryContent>(request.createCategoryContentDto);
+            var streetcodeCategoryContentEntity = _mapper.Map<DAL.Entities.Sources.StreetcodeCategoryContent>(request.CreateCategoryContentDto);
 
             var isDuplicate = await _repositoryWrapper.StreetcodeCategoryContentRepository.GetFirstOrDefaultAsync(predicate: c =>
             c.StreetcodeId == streetcodeCategoryContentEntity.StreetcodeId &&

--- a/Streetcode/Streetcode.BLL/MediatR/Sources/StreetcodeCategoryContent/Update/UpdateStreetcodeCategoryContentCommand.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Sources/StreetcodeCategoryContent/Update/UpdateStreetcodeCategoryContentCommand.cs
@@ -1,13 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using FluentResults;
+﻿using FluentResults;
 using MediatR;
 using Streetcode.BLL.DTO.Sources;
 
 namespace Streetcode.BLL.MediatR.Sources.StreetcodeCategoryContent.Update
 {
-    public record UpdateStreetcodeCategoryContentCommand(CategoryContentUpdateDTO categoryContentUpdateDTO) : IRequest<Result<StreetcodeCategoryContentDTO>>;
+    public record UpdateStreetcodeCategoryContentCommand(CategoryContentUpdateDTO CategoryContentUpdateDTO)
+        : IRequest<Result<StreetcodeCategoryContentDTO>>;
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Sources/StreetcodeCategoryContent/Update/UpdateStreetcodeCategoryContentHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Sources/StreetcodeCategoryContent/Update/UpdateStreetcodeCategoryContentHandler.cs
@@ -28,7 +28,7 @@ namespace Streetcode.BLL.MediatR.Sources.StreetcodeCategoryContent.Update
         public async Task<Result<StreetcodeCategoryContentDTO>> Handle(UpdateStreetcodeCategoryContentCommand request, CancellationToken cancellationToken)
         {
             var streetcodeCategoryContent = await _repositoryWrapper.StreetcodeCategoryContentRepository
-                .GetFirstOrDefaultAsync(t => t.Id == request.categoryContentUpdateDTO.Id);
+                .GetFirstOrDefaultAsync(t => t.Id == request.CategoryContentUpdateDTO.Id);
 
             if (streetcodeCategoryContent == null)
             {
@@ -37,13 +37,13 @@ namespace Streetcode.BLL.MediatR.Sources.StreetcodeCategoryContent.Update
                 return Result.Fail(new Error(errorMsg));
             }
 
-            _mapper.Map(request.categoryContentUpdateDTO, streetcodeCategoryContent);
+            _mapper.Map(request.CategoryContentUpdateDTO, streetcodeCategoryContent);
 
             var exists = await _repositoryWrapper.StreetcodeCategoryContentRepository
                 .GetFirstOrDefaultAsync(x =>
-                x.Id != request.categoryContentUpdateDTO.Id &&
-                x.SourceLinkCategoryId == request.categoryContentUpdateDTO.SourceLinkCategoryId &&
-                x.StreetcodeId == request.categoryContentUpdateDTO.StreetcodeId);
+                x.Id != request.CategoryContentUpdateDTO.Id &&
+                x.SourceLinkCategoryId == request.CategoryContentUpdateDTO.SourceLinkCategoryId &&
+                x.StreetcodeId == request.CategoryContentUpdateDTO.StreetcodeId);
 
             if(exists != null)
             {

--- a/Streetcode/Streetcode.BLL/Streetcode.BLL.csproj
+++ b/Streetcode/Streetcode.BLL/Streetcode.BLL.csproj
@@ -9,6 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Validators\Sourse\**" />
+    <EmbeddedResource Remove="Validators\Sourse\**" />
+    <None Remove="Validators\Sourse\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Ardalis.Specification" Version="8.0.0" />
     <PackageReference Include="AutoMapper" Version="12.0.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
@@ -45,7 +51,6 @@
     <Folder Include="Exceptions\" />
     <Folder Include="DTO\Instagram\" />
     <Folder Include="MediatR\Analytics\" />
-    <Folder Include="Validators\Sourse\" />
     <Folder Include="Validators\Email\" />
     <Folder Include="Validators\Helpers\" />
     <Folder Include="Validators\Payment\" />

--- a/Streetcode/Streetcode.BLL/Validators/Source/SourceLinkCategory/CreateSourceLinkCategoryValidator.cs
+++ b/Streetcode/Streetcode.BLL/Validators/Source/SourceLinkCategory/CreateSourceLinkCategoryValidator.cs
@@ -1,18 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using FluentValidation;
-using Streetcode.BLL.DTO.Sources;
+﻿using FluentValidation;
+using Streetcode.BLL.MediatR.Sources.SourceLinkCategory.Create;
 
 namespace Streetcode.BLL.Validators.Source.SourceLinkCategory
 {
-    public class CreateSourceLinkCategoryValidator : AbstractValidator<SourceLinkCategoryCreateDTO>
+    public class CreateSourceLinkCategoryValidator : AbstractValidator<CreateSourceLinkCategoryCommand>
     {
         public CreateSourceLinkCategoryValidator()
         {
-            RuleFor(dto => dto.Title)
+            RuleFor(c => c.SourceLinkCategoryCreateDTO.Title)
             .MaximumLength(23).WithMessage("Category can`t be more than 23 symbols.");
         }
     }

--- a/Streetcode/Streetcode.BLL/Validators/Source/SourceLinkCategory/UpdateSourceLinkCategoryValidator.cs
+++ b/Streetcode/Streetcode.BLL/Validators/Source/SourceLinkCategory/UpdateSourceLinkCategoryValidator.cs
@@ -1,21 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using FluentValidation;
-using Streetcode.BLL.DTO.Sources;
+﻿using FluentValidation;
+using Streetcode.BLL.MediatR.Sources.SourceLinkCategory.Update;
 
 namespace Streetcode.BLL.Validators.Source.SourceLinkCategory
 {
-    public class UpdateSourceLinkCategoryValidator : AbstractValidator<SourceLinkCategoryUpdateDTO>
+    public class UpdateSourceLinkCategoryValidator : AbstractValidator<UpdateSourceLinkCategoryCommand>
     {
         public UpdateSourceLinkCategoryValidator()
         {
-            RuleFor(dto => dto.Id)
+            RuleFor(c => c.SourceLinkCategoryUpdate.Id)
                 .NotEmpty().WithMessage("Id can`t be null.");
 
-            RuleFor(dto => dto.Title)
+            RuleFor(c => c.SourceLinkCategoryUpdate.Title)
             .MaximumLength(23).WithMessage("Category can`t be more than 23 symbols.");
         }
     }

--- a/Streetcode/Streetcode.BLL/Validators/Source/StreetcodeCategoryContent/CreateStreetcodeCategoryContentValidator.cs
+++ b/Streetcode/Streetcode.BLL/Validators/Source/StreetcodeCategoryContent/CreateStreetcodeCategoryContentValidator.cs
@@ -1,19 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using FluentValidation;
-using Streetcode.BLL.DTO.Sources;
+﻿using FluentValidation;
+using Streetcode.BLL.MediatR.Sources.StreetcodeCategoryContent.Create;
 
 namespace Streetcode.BLL.Validators.Source.StreetcodeCategoryContent
 {
-    public class CreateStreetcodeCategoryContentValidator : AbstractValidator<CategoryContentCreateDTO>
+    public class CreateStreetcodeCategoryContentValidator : AbstractValidator<CreateStreetcodeCategoryContentCommand>
     {
+        public const int MaxTextLength = 4000;
+
         public CreateStreetcodeCategoryContentValidator()
         {
-            RuleFor(dto => dto.Text)
-            .MaximumLength(4000).WithMessage("Text can`t be more than 4000 symbols.");
+            RuleFor(dto => dto.CreateCategoryContentDto.Text)
+            .MaximumLength(MaxTextLength).WithMessage("Text can`t be more than 4000 symbols.");
         }
     }
 }

--- a/Streetcode/Streetcode.BLL/Validators/Source/StreetcodeCategoryContent/UpdateStreetcodeCategoryContentValidator.cs
+++ b/Streetcode/Streetcode.BLL/Validators/Source/StreetcodeCategoryContent/UpdateStreetcodeCategoryContentValidator.cs
@@ -1,21 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using FluentValidation;
-using Streetcode.BLL.DTO.Sources;
+﻿using FluentValidation;
+using Streetcode.BLL.MediatR.Sources.StreetcodeCategoryContent.Update;
 
 namespace Streetcode.BLL.Validators.Source.StreetcodeCategoryContent
 {
-    public class UpdateStreetcodeCategoryContentValidator : AbstractValidator<CategoryContentUpdateDTO>
+    public class UpdateStreetcodeCategoryContentValidator : AbstractValidator<UpdateStreetcodeCategoryContentCommand>
     {
+        public const int MaxTextLength = 4000;
+
         public UpdateStreetcodeCategoryContentValidator()
         {
-            RuleFor(dto => dto.Text)
-            .MaximumLength(4000).WithMessage("Text can`t be more than 4000 symbols.");
+            RuleFor(dto => dto.CategoryContentUpdateDTO.Text)
+            .MaximumLength(MaxTextLength).WithMessage("Text can`t be more than 4000 symbols.");
 
-            RuleFor(dto => dto.Id)
+            RuleFor(dto => dto.CategoryContentUpdateDTO.Id)
                 .NotEmpty().WithMessage("Id can`t be null.");
         }
     }

--- a/Streetcode/Streetcode.BLL/Validators/Streetcode/BaseStreetcodeValidator.cs
+++ b/Streetcode/Streetcode.BLL/Validators/Streetcode/BaseStreetcodeValidator.cs
@@ -1,6 +1,8 @@
 ﻿using FluentValidation;
 using Streetcode.BLL.DTO.Media.Images;
 using Streetcode.BLL.DTO.Streetcode;
+using Streetcode.BLL.Validators.ArtGallery;
+using Streetcode.BLL.Validators.Media.Image.Art;
 using Streetcode.DAL.Enums;
 
 namespace Streetcode.BLL.Validators.Streetcode;
@@ -18,7 +20,9 @@ public class BaseStreetcodeValidator : AbstractValidator<StreetcodeCreateUpdateD
     public const int TeaserMaxLength = 520;
     public const int TeaserMaxLengthWithNewLine = 455;
 
-    public BaseStreetcodeValidator()
+    public BaseStreetcodeValidator(
+        StreetcodeArtSlideValidator streetcodeArtSlideValidator,
+        ArtCreateUpdateDTOValidator artCreateUpdateDTOValidator)
     {
         RuleFor(dto => dto.Index)
             .NotNull().WithMessage("Index is required.")
@@ -77,9 +81,15 @@ public class BaseStreetcodeValidator : AbstractValidator<StreetcodeCreateUpdateD
         RuleFor(dto => dto.ImagesDetails)
             .Must(HaveAtMostOneRelatedFigure)
             .WithMessage("There can be at most one related figure image.");
+
+        RuleForEach(dto => dto.StreetcodeArtSlides)
+            .SetValidator(streetcodeArtSlideValidator);
+
+        RuleForEach(dto => dto.Arts)
+            .SetValidator(artCreateUpdateDTOValidator);
     }
 
-    private bool BeValidTeaserLength(string? teaser)
+    private static bool BeValidTeaserLength(string? teaser)
     {
         if (string.IsNullOrEmpty(teaser))
         {
@@ -92,12 +102,12 @@ public class BaseStreetcodeValidator : AbstractValidator<StreetcodeCreateUpdateD
         return teaser.Length <= maxLength;
     }
 
-    private bool HaveExactlyOneBlackAndWhite(IEnumerable<ImageDetailsDto> images)
+    private static bool HaveExactlyOneBlackAndWhite(IEnumerable<ImageDetailsDto> images)
         => images is not null && images.Count(i => i.Alt == $"{(int)ImageAssigment.Blackandwhite}") == 1;
 
-    private bool HaveAtMostOneAnimation(IEnumerable<ImageDetailsDto> images)
+    private static bool HaveAtMostOneAnimation(IEnumerable<ImageDetailsDto> images)
         => images is null || images.Count(i => i.Alt == $"{(int)ImageAssigment.Animation}") <= 1;
 
-    private bool HaveAtMostOneRelatedFigure(IEnumerable<ImageDetailsDto> images)
+    private static bool HaveAtMostOneRelatedFigure(IEnumerable<ImageDetailsDto> images)
         => images is null || images.Count(i => i.Alt == $"{(int)ImageAssigment.Relatedfigure}") <= 1;
 }

--- a/Streetcode/Streetcode.BLL/Validators/Streetcode/BaseStreetcodeValidator.cs
+++ b/Streetcode/Streetcode.BLL/Validators/Streetcode/BaseStreetcodeValidator.cs
@@ -3,6 +3,7 @@ using Streetcode.BLL.DTO.Media.Images;
 using Streetcode.BLL.DTO.Streetcode;
 using Streetcode.BLL.Validators.ArtGallery;
 using Streetcode.BLL.Validators.Media.Image.Art;
+using Streetcode.BLL.Validators.Streetcode.ImageDetails;
 using Streetcode.DAL.Enums;
 
 namespace Streetcode.BLL.Validators.Streetcode;
@@ -22,7 +23,8 @@ public class BaseStreetcodeValidator : AbstractValidator<StreetcodeCreateUpdateD
 
     public BaseStreetcodeValidator(
         StreetcodeArtSlideValidator streetcodeArtSlideValidator,
-        ArtCreateUpdateDTOValidator artCreateUpdateDTOValidator)
+        ArtCreateUpdateDTOValidator artCreateUpdateDTOValidator,
+        ImageDetailsValidator imageDetailsValidator)
     {
         RuleFor(dto => dto.Index)
             .NotNull().WithMessage("Index is required.")
@@ -81,6 +83,9 @@ public class BaseStreetcodeValidator : AbstractValidator<StreetcodeCreateUpdateD
         RuleFor(dto => dto.ImagesDetails)
             .Must(HaveAtMostOneRelatedFigure)
             .WithMessage("There can be at most one related figure image.");
+
+        RuleForEach(dto => dto.ImagesDetails)
+            .SetValidator(imageDetailsValidator);
 
         RuleForEach(dto => dto.StreetcodeArtSlides)
             .SetValidator(streetcodeArtSlideValidator);

--- a/Streetcode/Streetcode.BLL/Validators/Streetcode/CreateStreetcodeValidator.cs
+++ b/Streetcode/Streetcode.BLL/Validators/Streetcode/CreateStreetcodeValidator.cs
@@ -1,11 +1,11 @@
 ﻿using FluentValidation;
-using Streetcode.BLL.DTO.Streetcode.Create;
+using Streetcode.BLL.MediatR.Streetcode.Streetcode.Create;
 using Streetcode.BLL.Validators.AdditionalContent.Tag;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 
 namespace Streetcode.BLL.Validators.Streetcode;
 
-public class CreateStreetcodeValidator : AbstractValidator<StreetcodeCreateDTO>
+public class CreateStreetcodeValidator : AbstractValidator<StreetcodeCreateCommand>
 {
     private readonly IRepositoryWrapper _repositoryWrapper;
 
@@ -16,21 +16,21 @@ public class CreateStreetcodeValidator : AbstractValidator<StreetcodeCreateDTO>
     {
         _repositoryWrapper = repositoryWrapper;
 
-        RuleFor(dto => dto).SetValidator(baseStreetcodeValidator);
+        RuleFor(c => c.NewStreetcode).SetValidator(baseStreetcodeValidator);
 
-        RuleFor(dto => dto.Index)
+        RuleFor(c => c.NewStreetcode.Index)
             .MustAsync(BeUniqueIndex).WithMessage("Index must be unique.");
 
-        RuleFor(dto => dto.ImagesDetails)
+        RuleFor(c => c.NewStreetcode.ImagesDetails)
             .NotEmpty()
             .WithMessage("At least one image detail is required.");
 
-        RuleForEach(dto => dto.ImagesDetails.Select(x => x.ImageId))
+        RuleForEach(c => c.NewStreetcode.ImagesDetails.Select(x => x.ImageId))
             .MustAsync(HasExistingImage)
             .WithMessage("One or more images do not exist.")
             .OverridePropertyName("Streetcode.ImagesDetails.ImageId");
 
-        RuleForEach(dto => dto.Tags).SetValidator(tagValidator);
+        RuleForEach(c => c.NewStreetcode.Tags).SetValidator(tagValidator);
     }
 
     private async Task<bool> BeUniqueIndex(int index, CancellationToken cancellationToken)

--- a/Streetcode/Streetcode.BLL/Validators/Streetcode/ImageDetails/ImageDetailsValidator.cs
+++ b/Streetcode/Streetcode.BLL/Validators/Streetcode/ImageDetails/ImageDetailsValidator.cs
@@ -1,0 +1,48 @@
+﻿using FluentValidation;
+using Streetcode.BLL.DTO.Media.Images;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+
+namespace Streetcode.BLL.Validators.Streetcode.ImageDetails;
+
+public class ImageDetailsValidator : AbstractValidator<ImageDetailsDto>
+{
+    public const int TitleMaxLength = 100;
+    public const int AltMaxLength = 200;
+
+    private readonly IRepositoryWrapper _repositoryWrapper;
+
+    public ImageDetailsValidator(IRepositoryWrapper repositoryWrapper)
+    {
+        _repositoryWrapper = repositoryWrapper;
+
+        RuleFor(dto => dto)
+            .MustAsync(BeUniqueImageIdWithImageDetails)
+            .WithMessage("An ImageDetails entry with the same ImageId already exists.")
+            .When(dto => dto.ImageId != 0);
+
+        RuleFor(dto => dto.Title)
+            .MaximumLength(TitleMaxLength)
+            .WithMessage($"Title cannot exceed {TitleMaxLength} characters.");
+
+        RuleFor(dto => dto.Alt)
+            .MaximumLength(AltMaxLength)
+            .WithMessage($"Alt text cannot exceed {AltMaxLength} characters.");
+
+        RuleFor(dto => dto.ImageId)
+            .MustAsync(HasExistingImage)
+            .WithMessage("The specified ImageId does not exist.");
+    }
+
+    private async Task<bool> BeUniqueImageIdWithImageDetails(ImageDetailsDto imageDetails, CancellationToken cancellationToken)
+    {
+        var existingImageDetails = await _repositoryWrapper.ImageDetailsRepository
+            .GetFirstOrDefaultAsync(id => id.ImageId == imageDetails.ImageId);
+        return existingImageDetails == null || existingImageDetails.Id == imageDetails.Id;
+    }
+
+    private async Task<bool> HasExistingImage(int imageId, CancellationToken token)
+    {
+        var image = await _repositoryWrapper.ImageRepository.GetFirstOrDefaultAsync(i => i.Id == imageId);
+        return image != null;
+    }
+}

--- a/Streetcode/Streetcode.BLL/Validators/Streetcode/UpdateStreetcodeValidator.cs
+++ b/Streetcode/Streetcode.BLL/Validators/Streetcode/UpdateStreetcodeValidator.cs
@@ -1,11 +1,12 @@
 ﻿using FluentValidation;
 using Streetcode.BLL.DTO.Streetcode.Update;
+using Streetcode.BLL.MediatR.Streetcode.Streetcode.Update;
 using Streetcode.BLL.Validators.AdditionalContent.Tag;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 
 namespace Streetcode.BLL.Validators.Streetcode
 {
-    public class UpdateStreetcodeValidator : AbstractValidator<StreetcodeUpdateDTO>
+    public class UpdateStreetcodeValidator : AbstractValidator<UpdateStreetcodeCommand>
     {
         private readonly IRepositoryWrapper _repositoryWrapper;
 
@@ -16,12 +17,12 @@ namespace Streetcode.BLL.Validators.Streetcode
         {
             _repositoryWrapper = repositoryWrapper;
 
-            RuleFor(dto => dto).SetValidator(baseStreetcodeValidator);
+            RuleFor(c => c.Streetcode).SetValidator(baseStreetcodeValidator);
 
-            RuleFor(dto => dto)
+            RuleFor(c => c.Streetcode)
                 .MustAsync(BeUniqueIndex).WithMessage("Index must be unique.");
 
-            RuleForEach(dto => dto.Tags).SetValidator(tagValidator);
+            RuleForEach(c => c.Streetcode.Tags).SetValidator(tagValidator);
         }
 
         private async Task<bool> BeUniqueIndex(StreetcodeUpdateDTO streetcode, CancellationToken cancellationToken)

--- a/Streetcode/Streetcode.XUnitTest/BLL/Validators/Streetcode/BaseStreetcodeValidatorsTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/Validators/Streetcode/BaseStreetcodeValidatorsTests.cs
@@ -1,8 +1,15 @@
 ﻿using FluentValidation.TestHelper;
+using Moq;
+using Streetcode.BLL.DTO.ArtGallery;
+using Streetcode.BLL.DTO.Media.Art;
 using Streetcode.BLL.DTO.Media.Images;
 using Streetcode.BLL.DTO.Streetcode;
+using Streetcode.BLL.Validators.ArtGallery;
+using Streetcode.BLL.Validators.Media.Image.Art;
 using Streetcode.BLL.Validators.Streetcode;
+using Streetcode.BLL.Validators.Streetcode.ImageDetails;
 using Streetcode.DAL.Enums;
+using Streetcode.DAL.Repositories.Interfaces.Base;
 using Xunit;
 
 namespace Streetcode.XUnitTest.BLL.Validators.Streetcode;
@@ -10,10 +17,20 @@ namespace Streetcode.XUnitTest.BLL.Validators.Streetcode;
 public class BaseStreetcodeValidatorsTests
 {
     private readonly BaseStreetcodeValidator _validator;
+    private readonly Mock<StreetcodeArtSlideValidator> _mockStreetcodeArtSlideValidator;
+    private readonly Mock<ArtCreateUpdateDTOValidator> _mockArtCreateUpdateDTOValidator;
+    private readonly Mock<ImageDetailsValidator> _mockImageDetailsValidator;
 
     public BaseStreetcodeValidatorsTests()
     {
-        _validator = new BaseStreetcodeValidator();
+        _mockStreetcodeArtSlideValidator = new Mock<StreetcodeArtSlideValidator>();
+        _mockArtCreateUpdateDTOValidator = new Mock<ArtCreateUpdateDTOValidator>();
+        _mockImageDetailsValidator = new Mock<ImageDetailsValidator>(Mock.Of<IRepositoryWrapper>());
+
+        _validator = new BaseStreetcodeValidator(
+            _mockStreetcodeArtSlideValidator.Object,
+            _mockArtCreateUpdateDTOValidator.Object,
+            _mockImageDetailsValidator.Object);
     }
 
     [Fact]
@@ -37,6 +54,22 @@ public class BaseStreetcodeValidatorsTests
         // Arrange
         var streetcode = GetValidStreetcodeDto();
         streetcode.Index = index;
+        var expectedMessage = $"Index must be between {BaseStreetcodeValidator.IndexMinValue} and {BaseStreetcodeValidator.IndexMaxValue}.";
+
+        // Act
+        var result = _validator.TestValidate(streetcode);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(sc => sc.Index)
+            .WithErrorMessage(expectedMessage);
+    }
+
+    [Fact]
+    public void ShouldReturnError_WhenIndexIsNull()
+    {
+        // Arrange
+        var streetcode = GetValidStreetcodeDto();
+        streetcode.Index = 0; // This will be treated as null/invalid
         var expectedMessage = $"Index must be between {BaseStreetcodeValidator.IndexMinValue} and {BaseStreetcodeValidator.IndexMaxValue}.";
 
         // Act
@@ -148,7 +181,7 @@ public class BaseStreetcodeValidatorsTests
     {
         // Arrange
         var streetcode = GetValidStreetcodeDto();
-        streetcode.TransliterationUrl = new string('A', BaseStreetcodeValidator.TransliterationUrlMaxLength + 1);
+        streetcode.TransliterationUrl = new string('a', BaseStreetcodeValidator.TransliterationUrlMaxLength + 1);
         var expectedMessage = $"Transliteration URL cannot exceed {BaseStreetcodeValidator.TransliterationUrlMaxLength} characters.";
 
         // Act
@@ -283,6 +316,20 @@ public class BaseStreetcodeValidatorsTests
     }
 
     [Fact]
+    public void ShouldReturnSuccess_WhenTeaserIsValidLength_WithNewline()
+    {
+        // Arrange
+        var streetcode = GetValidStreetcodeDto();
+        streetcode.Teaser = new string('A', BaseStreetcodeValidator.TeaserMaxLengthWithNewLine - 1) + "\n";
+
+        // Act
+        var result = _validator.TestValidate(streetcode);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(sc => sc.Teaser);
+    }
+
+    [Fact]
     public void ShouldReturnError_WhenStreetcodeTypeIsInvalid()
     {
         // Arrange
@@ -331,6 +378,22 @@ public class BaseStreetcodeValidatorsTests
     }
 
     [Fact]
+    public void ShouldReturnSuccess_WhenEventStreetcodeHasEmpty_FirstNameAndLastName()
+    {
+        // Arrange
+        var streetcode = GetValidStreetcodeDto();
+        streetcode.StreetcodeType = StreetcodeType.Event;
+        streetcode.FirstName = null;
+        streetcode.LastName = null;
+
+        // Act
+        var result = _validator.TestValidate(streetcode);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(sc => sc);
+    }
+
+    [Fact]
     public void ShouldReturnError_WhenNotExactlyOneBlackAndWhiteImage()
     {
         // Arrange
@@ -347,7 +410,7 @@ public class BaseStreetcodeValidatorsTests
     }
 
     [Fact]
-    public void ShouldReturnError_WhenThereAreTwoColoredImages()
+    public void ShouldReturnError_WhenThereAreTwoAnimationImages()
     {
         // Arrange
         var streetcode = GetValidStreetcodeDto();
@@ -355,15 +418,15 @@ public class BaseStreetcodeValidatorsTests
         [
             new()
             {
-                Alt = "1",
+                Alt = "1", // Black and white
             },
             new()
             {
-                Alt = "0",
+                Alt = "0", // Animation
             },
             new()
             {
-                Alt = "0",
+                Alt = "0", // Animation (duplicate)
             },
         ];
 
@@ -386,15 +449,15 @@ public class BaseStreetcodeValidatorsTests
         [
             new()
             {
-                Alt = "1",
+                Alt = "1", // Black and white
             },
             new()
             {
-                Alt = "2",
+                Alt = "2", // Related figure
             },
             new()
             {
-                Alt = "2",
+                Alt = "2", // Related figure (duplicate)
             },
         ];
         var expectedMessage = "There can be at most one related figure image.";
@@ -405,6 +468,40 @@ public class BaseStreetcodeValidatorsTests
         // Assert
         result.ShouldHaveValidationErrorFor(sc => sc.ImagesDetails)
             .WithErrorMessage(expectedMessage);
+    }
+
+    [Fact]
+    public void ShouldReturnSuccess_WhenValidImageAssignments()
+    {
+        // Arrange
+        var streetcode = GetValidStreetcodeDto();
+        streetcode.ImagesDetails =
+        [
+            new()
+            {
+                Alt = "1", // Black and white (required)
+                ImageId = 1,
+                Title = "Black and white"
+            },
+            new()
+            {
+                Alt = "0", // Animation (optional, max 1)
+                ImageId = 2,
+                Title = "Animation"
+            },
+            new()
+            {
+                Alt = "2", // Related figure (optional, max 1)
+                ImageId = 3,
+                Title = "Related figure"
+            },
+        ];
+
+        // Act
+        var result = _validator.TestValidate(streetcode);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(sc => sc.ImagesDetails);
     }
 
     private static StreetcodeCreateUpdateDTO GetValidStreetcodeDto()
@@ -428,9 +525,11 @@ public class BaseStreetcodeValidatorsTests
                     Id = 2,
                     ImageId = 5,
                     Title = "Franko_black&white",
-                    Alt = "1",
+                    Alt = "1", // Black and white image assignment
                 },
-            ]
+            ],
+            StreetcodeArtSlides = new List<StreetcodeArtSlideCreateUpdateDTO>(),
+            Arts = new List<ArtCreateUpdateDTO>()
         };
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/BLL/Validators/Streetcode/CreateStreetcodeValidatorTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/Validators/Streetcode/CreateStreetcodeValidatorTests.cs
@@ -7,6 +7,7 @@ using Streetcode.BLL.DTO.AdditionalContent.Tag;
 using Streetcode.BLL.DTO.Media.Images;
 using Streetcode.BLL.DTO.Streetcode;
 using Streetcode.BLL.DTO.Streetcode.Create;
+using Streetcode.BLL.MediatR.Streetcode.Streetcode.Create;
 using Streetcode.BLL.Validators.AdditionalContent.Tag;
 using Streetcode.BLL.Validators.ArtGallery;
 using Streetcode.BLL.Validators.Media.Image.Art;
@@ -50,11 +51,11 @@ public class CreateStreetcodeValidatorTests
     public async Task ShouldReturnSuccessResult_WhenAllFieldsAreValid()
     {
         // Arrange
-        var streetcode = GetValidStreetcodeDto();
+        var command = GetValidStreetcodeCommand();
         SetupRepositoryWrapperForValidScenario();
 
         // Act
-        var result = await _validator.ValidateAsync(streetcode);
+        var result = await _validator.ValidateAsync(command);
 
         // Assert
         Assert.True(result.IsValid);
@@ -65,15 +66,15 @@ public class CreateStreetcodeValidatorTests
     public async Task ShouldReturnError_WhenIndexIsNotUnique()
     {
         // Arrange
-        var streetcode = GetValidStreetcodeDto();
+        var command = GetValidStreetcodeCommand();
         SetupRepositoryWrapper(1);
         var expectedMessage = "Index must be unique.";
 
         // Act
-        var result = await _validator.TestValidateAsync(streetcode);
+        var result = await _validator.TestValidateAsync(command);
 
         // Assert
-        result.ShouldHaveValidationErrorFor(sc => sc.Index)
+        result.ShouldHaveValidationErrorFor(c => c.NewStreetcode.Index)
             .WithErrorMessage(expectedMessage);
     }
 
@@ -81,16 +82,16 @@ public class CreateStreetcodeValidatorTests
     public async Task ShouldReturnError_WhenImagesDetailsIsEmpty()
     {
         // Arrange
-        var streetcode = GetValidStreetcodeDto();
-        streetcode.ImagesDetails = new List<ImageDetailsDto>();
+        var command = GetValidStreetcodeCommand();
+        command.NewStreetcode.ImagesDetails = new List<ImageDetailsDto>();
         SetupRepositoryWrapperForValidScenario();
         var expectedMessage = "At least one image detail is required.";
 
         // Act
-        var result = await _validator.TestValidateAsync(streetcode);
+        var result = await _validator.TestValidateAsync(command);
 
         // Assert
-        result.ShouldHaveValidationErrorFor(sc => sc.ImagesDetails)
+        result.ShouldHaveValidationErrorFor(c => c.NewStreetcode.ImagesDetails)
             .WithErrorMessage(expectedMessage);
     }
 
@@ -98,9 +99,9 @@ public class CreateStreetcodeValidatorTests
     public async Task ShouldReturnError_WhenImageDoesNotExist()
     {
         // Arrange
-        var streetcode = GetValidStreetcodeDto();
+        var command = GetValidStreetcodeCommand();
         SetupRepositoryWrapperForValidScenario();
-        streetcode.ImagesDetails.First().ImageId = 99;
+        command.NewStreetcode.ImagesDetails.First().ImageId = 99;
         _mockRepositoryWrapper
             .Setup(repo => repo.ImageRepository.GetFirstOrDefaultAsync(
                 It.IsAny<Expression<Func<Image, bool>>>(),
@@ -110,7 +111,7 @@ public class CreateStreetcodeValidatorTests
         var expectedMessage = "One or more images do not exist.";
 
         // Act
-        var result = await _validator.TestValidateAsync(streetcode);
+        var result = await _validator.TestValidateAsync(command);
 
         // Assert
         result.ShouldHaveValidationErrorFor($"Streetcode.ImagesDetails.ImageId[{0}]")
@@ -121,11 +122,11 @@ public class CreateStreetcodeValidatorTests
     public async Task ShouldCallBaseValidator()
     {
         // Arrange
-        var streetcode = GetValidStreetcodeDto();
+        var command = GetValidStreetcodeCommand();
         SetupRepositoryWrapperForValidScenario();
 
         // Act
-        var result = await _validator.ValidateAsync(streetcode);
+        var result = await _validator.ValidateAsync(command);
 
         // Assert
         _mockBaseStreetcodeValidator.Verify(v => v.ValidateAsync(It.IsAny<ValidationContext<StreetcodeCreateUpdateDTO>>(), default), Times.Once);
@@ -135,11 +136,11 @@ public class CreateStreetcodeValidatorTests
     public async Task ShouldCallChildValidators()
     {
         // Arrange
-        var streetcode = GetValidStreetcodeDto();
+        var command = GetValidStreetcodeCommand();
         SetupRepositoryWrapperForValidScenario();
 
         // Act
-        var result = await _validator.ValidateAsync(streetcode);
+        await _validator.ValidateAsync(command);
 
         // Assert
         _mockTagValidator.Verify(v => v.ValidateAsync(It.IsAny<ValidationContext<CreateTagDTO>>(), default), Times.AtLeast(1));
@@ -175,9 +176,9 @@ public class CreateStreetcodeValidatorTests
             .ReturnsAsync(new Image { Id = id });
     }
 
-    private static StreetcodeCreateDTO GetValidStreetcodeDto()
+    private static StreetcodeCreateCommand GetValidStreetcodeCommand()
     {
-        return new StreetcodeCreateDTO
+        return new StreetcodeCreateCommand(new StreetcodeCreateDTO
         {
             Index = 1,
             FirstName = "Ivan",
@@ -203,6 +204,6 @@ public class CreateStreetcodeValidatorTests
                     Alt = "1",
                 },
             ]
-        };
+        });
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/BLL/Validators/Streetcode/CreateStreetcodeValidatorTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/Validators/Streetcode/CreateStreetcodeValidatorTests.cs
@@ -8,7 +8,10 @@ using Streetcode.BLL.DTO.Media.Images;
 using Streetcode.BLL.DTO.Streetcode;
 using Streetcode.BLL.DTO.Streetcode.Create;
 using Streetcode.BLL.Validators.AdditionalContent.Tag;
+using Streetcode.BLL.Validators.ArtGallery;
+using Streetcode.BLL.Validators.Media.Image.Art;
 using Streetcode.BLL.Validators.Streetcode;
+using Streetcode.BLL.Validators.Streetcode.ImageDetails;
 using Streetcode.DAL.Entities.Media.Images;
 using Streetcode.DAL.Entities.Streetcode;
 using Streetcode.DAL.Enums;
@@ -27,8 +30,15 @@ public class CreateStreetcodeValidatorTests
     public CreateStreetcodeValidatorTests()
     {
         _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
-        _mockBaseStreetcodeValidator = new Mock<BaseStreetcodeValidator>();
         _mockTagValidator = new Mock<TagValidator>();
+        var mockArtSlideValidator = new Mock<StreetcodeArtSlideValidator>();
+        var mockImageDetailsValidator = new Mock<ImageDetailsValidator>(_mockRepositoryWrapper.Object);
+        var mockArtValidator = new Mock<ArtCreateUpdateDTOValidator>();
+
+        _mockBaseStreetcodeValidator = new Mock<BaseStreetcodeValidator>(
+            mockArtSlideValidator.Object,
+            mockArtValidator.Object,
+            mockImageDetailsValidator.Object);
 
         _validator = new CreateStreetcodeValidator(
             _mockRepositoryWrapper.Object,

--- a/Streetcode/Streetcode.XUnitTest/BLL/Validators/Streetcode/ImageDetails/ImageDetailsValidatorTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/Validators/Streetcode/ImageDetails/ImageDetailsValidatorTests.cs
@@ -1,0 +1,384 @@
+using System.Linq.Expressions;
+using FluentValidation.TestHelper;
+using Microsoft.EntityFrameworkCore.Query;
+using Moq;
+using Streetcode.BLL.DTO.Media.Images;
+using Streetcode.BLL.Validators.Streetcode.ImageDetails;
+using Streetcode.DAL.Entities.Media.Images;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using Xunit;
+
+namespace Streetcode.XUnitTest.BLL.Validators.Streetcode.ImageDetails;
+
+public class ImageDetailsValidatorTests
+{
+    private readonly ImageDetailsValidator _validator;
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+
+    public ImageDetailsValidatorTests()
+    {
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+        _validator = new ImageDetailsValidator(_mockRepositoryWrapper.Object);
+    }
+
+    [Fact]
+    public async Task ShouldReturnSuccessResult_WhenAllFieldsAreValid()
+    {
+        // Arrange
+        var imageDetails = GetValidImageDetailsDto();
+        SetupRepositoryForValidScenario();
+
+        // Act
+        var result = await _validator.TestValidateAsync(imageDetails);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public async Task ShouldReturnError_WhenTitleExceedsMaxLength()
+    {
+        // Arrange
+        var imageDetails = GetValidImageDetailsDto();
+        imageDetails.Title = new string('A', ImageDetailsValidator.TitleMaxLength + 1);
+        SetupRepositoryForValidScenario();
+        var expectedMessage = $"Title cannot exceed {ImageDetailsValidator.TitleMaxLength} characters.";
+
+        // Act
+        var result = await _validator.TestValidateAsync(imageDetails);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Title)
+            .WithErrorMessage(expectedMessage);
+    }
+
+    [Fact]
+    public async Task ShouldReturnSuccess_WhenTitleIsAtMaxLength()
+    {
+        // Arrange
+        var imageDetails = GetValidImageDetailsDto();
+        imageDetails.Title = new string('A', ImageDetailsValidator.TitleMaxLength);
+        SetupRepositoryForValidScenario();
+
+        // Act
+        var result = await _validator.TestValidateAsync(imageDetails);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.Title);
+    }
+
+    [Fact]
+    public async Task ShouldReturnSuccess_WhenTitleIsNull()
+    {
+        // Arrange
+        var imageDetails = GetValidImageDetailsDto();
+        imageDetails.Title = null;
+        SetupRepositoryForValidScenario();
+
+        // Act
+        var result = await _validator.TestValidateAsync(imageDetails);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.Title);
+    }
+
+    [Fact]
+    public async Task ShouldReturnSuccess_WhenTitleIsEmpty()
+    {
+        // Arrange
+        var imageDetails = GetValidImageDetailsDto();
+        imageDetails.Title = string.Empty;
+        SetupRepositoryForValidScenario();
+
+        // Act
+        var result = await _validator.TestValidateAsync(imageDetails);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.Title);
+    }
+
+    [Fact]
+    public async Task ShouldReturnError_WhenAltExceedsMaxLength()
+    {
+        // Arrange
+        var imageDetails = GetValidImageDetailsDto();
+        imageDetails.Alt = new string('B', ImageDetailsValidator.AltMaxLength + 1);
+        SetupRepositoryForValidScenario();
+        var expectedMessage = $"Alt text cannot exceed {ImageDetailsValidator.AltMaxLength} characters.";
+
+        // Act
+        var result = await _validator.TestValidateAsync(imageDetails);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Alt)
+            .WithErrorMessage(expectedMessage);
+    }
+
+    [Fact]
+    public async Task ShouldReturnSuccess_WhenAltIsAtMaxLength()
+    {
+        // Arrange
+        var imageDetails = GetValidImageDetailsDto();
+        imageDetails.Alt = new string('B', ImageDetailsValidator.AltMaxLength);
+        SetupRepositoryForValidScenario();
+
+        // Act
+        var result = await _validator.TestValidateAsync(imageDetails);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.Alt);
+    }
+
+    [Fact]
+    public async Task ShouldReturnSuccess_WhenAltIsNull()
+    {
+        // Arrange
+        var imageDetails = GetValidImageDetailsDto();
+        imageDetails.Alt = null;
+        SetupRepositoryForValidScenario();
+
+        // Act
+        var result = await _validator.TestValidateAsync(imageDetails);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.Alt);
+    }
+
+    [Fact]
+    public async Task ShouldReturnSuccess_WhenAltIsEmpty()
+    {
+        // Arrange
+        var imageDetails = GetValidImageDetailsDto();
+        imageDetails.Alt = string.Empty;
+        SetupRepositoryForValidScenario();
+
+        // Act
+        var result = await _validator.TestValidateAsync(imageDetails);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.Alt);
+    }
+
+    [Fact]
+    public async Task ShouldReturnError_WhenImageIdDoesNotExist()
+    {
+        // Arrange
+        var imageDetails = GetValidImageDetailsDto();
+        SetupRepositoryForNonExistentImage();
+        SetupRepositoryForNoExistingImageDetails();
+        var expectedMessage = "The specified ImageId does not exist.";
+
+        // Act
+        var result = await _validator.TestValidateAsync(imageDetails);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.ImageId)
+            .WithErrorMessage(expectedMessage);
+    }
+
+    [Fact]
+    public async Task ShouldReturnSuccess_WhenImageIdExists()
+    {
+        // Arrange
+        var imageDetails = GetValidImageDetailsDto();
+        SetupRepositoryForExistingImage(imageDetails.ImageId);
+        SetupRepositoryForNoExistingImageDetails();
+
+        // Act
+        var result = await _validator.TestValidateAsync(imageDetails);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.ImageId);
+    }
+
+    [Fact]
+    public async Task ShouldReturnError_WhenImageDetailsWithSameImageIdAlreadyExists()
+    {
+        // Arrange
+        var imageDetails = GetValidImageDetailsDto();
+        imageDetails.ImageId = 5;
+        SetupRepositoryForExistingImage(imageDetails.ImageId);
+        SetupRepositoryForExistingImageDetails(imageDetails.ImageId, differentId: 999);
+        var expectedMessage = "An ImageDetails entry with the same ImageId already exists.";
+
+        // Act
+        var result = await _validator.TestValidateAsync(imageDetails);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x)
+            .WithErrorMessage(expectedMessage);
+    }
+
+    [Fact]
+    public async Task ShouldReturnSuccess_WhenImageDetailsWithSameImageIdIsSameEntity()
+    {
+        // Arrange
+        var imageDetails = GetValidImageDetailsDto();
+        imageDetails.Id = 10;
+        imageDetails.ImageId = 5;
+        SetupRepositoryForExistingImage(imageDetails.ImageId);
+        SetupRepositoryForExistingImageDetails(imageDetails.ImageId, imageDetails.Id);
+
+        // Act
+        var result = await _validator.TestValidateAsync(imageDetails);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x);
+    }
+
+    [Fact]
+    public async Task ShouldReturnSuccess_WhenNoExistingImageDetailsForImageId()
+    {
+        // Arrange
+        var imageDetails = GetValidImageDetailsDto();
+        SetupRepositoryForExistingImage(imageDetails.ImageId);
+        SetupRepositoryForNoExistingImageDetails();
+
+        // Act
+        var result = await _validator.TestValidateAsync(imageDetails);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x);
+    }
+
+    [Fact]
+    public async Task ShouldNotValidateUniqueness_WhenImageIdIsZero()
+    {
+        // Arrange
+        var imageDetails = GetValidImageDetailsDto();
+        imageDetails.ImageId = 0;
+        SetupRepositoryForNonExistentImage();
+
+        // Act
+        var result = await _validator.TestValidateAsync(imageDetails);
+
+        // Assert
+        // Should have error for non-existent image but not for uniqueness
+        result.ShouldHaveValidationErrorFor(x => x.ImageId)
+            .WithErrorMessage("The specified ImageId does not exist.");
+
+        // Verify that ImageDetails repository was not called for uniqueness check
+        _mockRepositoryWrapper.Verify(
+            r => r.ImageDetailsRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<DAL.Entities.Media.Images.ImageDetails, bool>>>(),
+                It.IsAny<Func<IQueryable<DAL.Entities.Media.Images.ImageDetails>, IIncludableQueryable<DAL.Entities.Media.Images.ImageDetails, object>>>()),
+            Times.Never);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public async Task ShouldReturnError_WhenImageIdIsNegative(int negativeImageId)
+    {
+        // Arrange
+        var imageDetails = GetValidImageDetailsDto();
+        imageDetails.ImageId = negativeImageId;
+        SetupRepositoryForNonExistentImage();
+        SetupRepositoryForNoExistingImageDetails();
+
+        // Act
+        var result = await _validator.TestValidateAsync(imageDetails);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.ImageId)
+            .WithErrorMessage("The specified ImageId does not exist.");
+    }
+
+    [Fact]
+    public async Task ShouldReturnMultipleErrors_WhenMultipleValidationsFail()
+    {
+        // Arrange
+        var imageDetails = GetValidImageDetailsDto();
+        imageDetails.Title = new string('A', ImageDetailsValidator.TitleMaxLength + 1);
+        imageDetails.Alt = new string('B', ImageDetailsValidator.AltMaxLength + 1);
+        imageDetails.ImageId = 999;
+        SetupRepositoryForNonExistentImage();
+        SetupRepositoryForExistingImageDetails(999, differentId: 888);
+
+        // Act
+        var result = await _validator.TestValidateAsync(imageDetails);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Title);
+        result.ShouldHaveValidationErrorFor(x => x.Alt);
+        result.ShouldHaveValidationErrorFor(x => x.ImageId);
+        result.ShouldHaveValidationErrorFor(x => x);
+    }
+
+    [Fact]
+    public async Task ShouldCallRepositoryOnce_WhenValidating()
+    {
+        // Arrange
+        var imageDetails = GetValidImageDetailsDto();
+        SetupRepositoryForValidScenario();
+
+        // Act
+        await _validator.TestValidateAsync(imageDetails);
+
+        // Assert
+        _mockRepositoryWrapper.Verify(
+            r => r.ImageRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<Image, bool>>>(),
+                It.IsAny<Func<IQueryable<Image>, IIncludableQueryable<Image, object>>>()),
+            Times.Once);
+
+        _mockRepositoryWrapper.Verify(
+            r => r.ImageDetailsRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<DAL.Entities.Media.Images.ImageDetails, bool>>>(),
+                It.IsAny<Func<IQueryable<DAL.Entities.Media.Images.ImageDetails>, IIncludableQueryable<DAL.Entities.Media.Images.ImageDetails, object>>>()),
+            Times.Once);
+    }
+
+    private ImageDetailsDto GetValidImageDetailsDto()
+    {
+        return new ImageDetailsDto
+        {
+            Id = 1,
+            ImageId = 5,
+            Title = "Valid Title",
+            Alt = "Valid Alt Text"
+        };
+    }
+
+    private void SetupRepositoryForValidScenario()
+    {
+        SetupRepositoryForExistingImage(5);
+        SetupRepositoryForNoExistingImageDetails();
+    }
+
+    private void SetupRepositoryForExistingImage(int imageId)
+    {
+        _mockRepositoryWrapper.Setup(r => r.ImageRepository.GetFirstOrDefaultAsync(
+                It.Is<Expression<Func<Image, bool>>>(expr => true),
+                It.IsAny<Func<IQueryable<Image>, IIncludableQueryable<Image, object>>>()))
+            .ReturnsAsync(new Image { Id = imageId });
+    }
+
+    private void SetupRepositoryForNonExistentImage()
+    {
+        _mockRepositoryWrapper.Setup(r => r.ImageRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<Image, bool>>>(),
+                It.IsAny<Func<IQueryable<Image>, IIncludableQueryable<Image, object>>>()))
+            .ReturnsAsync((Image?)null);
+    }
+
+    private void SetupRepositoryForNoExistingImageDetails()
+    {
+        _mockRepositoryWrapper.Setup(r => r.ImageDetailsRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<DAL.Entities.Media.Images.ImageDetails, bool>>>(),
+                It.IsAny<Func<IQueryable<DAL.Entities.Media.Images.ImageDetails>, IIncludableQueryable<DAL.Entities.Media.Images.ImageDetails, object>>>()))
+            .ReturnsAsync((DAL.Entities.Media.Images.ImageDetails?)null);
+    }
+
+    private void SetupRepositoryForExistingImageDetails(int imageId, int differentId)
+    {
+        _mockRepositoryWrapper.Setup(r => r.ImageDetailsRepository.GetFirstOrDefaultAsync(
+                It.Is<Expression<Func<DAL.Entities.Media.Images.ImageDetails, bool>>>(expr => true),
+                It.IsAny<Func<IQueryable<DAL.Entities.Media.Images.ImageDetails>, IIncludableQueryable<DAL.Entities.Media.Images.ImageDetails, object>>>()))
+            .ReturnsAsync(new DAL.Entities.Media.Images.ImageDetails
+            {
+                Id = differentId,
+                ImageId = imageId
+            });
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/BLL/Validators/Streetcode/UpdateStreetcodeValidatorTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/Validators/Streetcode/UpdateStreetcodeValidatorTests.cs
@@ -6,7 +6,10 @@ using Streetcode.BLL.DTO.AdditionalContent.Tag;
 using Streetcode.BLL.DTO.Streetcode;
 using Streetcode.BLL.DTO.Streetcode.Update;
 using Streetcode.BLL.Validators.AdditionalContent.Tag;
+using Streetcode.BLL.Validators.ArtGallery;
+using Streetcode.BLL.Validators.Media.Image.Art;
 using Streetcode.BLL.Validators.Streetcode;
+using Streetcode.BLL.Validators.Streetcode.ImageDetails;
 using Streetcode.DAL.Entities.Streetcode;
 using Streetcode.DAL.Enums;
 using Streetcode.DAL.Repositories.Interfaces.Base;
@@ -26,6 +29,14 @@ public class UpdateStreetcodeValidatorTests
         _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
         _mockBaseStreetcodeValidator = new Mock<BaseStreetcodeValidator>();
         _mockTagValidator = new Mock<TagValidator>();
+        var mockArtSlideValidator = new Mock<StreetcodeArtSlideValidator>();
+        var mockImageDetailsValidator = new Mock<ImageDetailsValidator>(_mockRepositoryWrapper.Object);
+        var mockArtValidator = new Mock<ArtCreateUpdateDTOValidator>();
+
+        _mockBaseStreetcodeValidator = new Mock<BaseStreetcodeValidator>(
+            mockArtSlideValidator.Object,
+            mockArtValidator.Object,
+            mockImageDetailsValidator.Object);
 
         _validator = new UpdateStreetcodeValidator(
             _mockRepositoryWrapper.Object,

--- a/Streetcode/Streetcode.XUnitTest/BLL/Validators/Streetcode/UpdateStreetcodeValidatorTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/Validators/Streetcode/UpdateStreetcodeValidatorTests.cs
@@ -5,6 +5,7 @@ using Moq;
 using Streetcode.BLL.DTO.AdditionalContent.Tag;
 using Streetcode.BLL.DTO.Streetcode;
 using Streetcode.BLL.DTO.Streetcode.Update;
+using Streetcode.BLL.MediatR.Streetcode.Streetcode.Update;
 using Streetcode.BLL.Validators.AdditionalContent.Tag;
 using Streetcode.BLL.Validators.ArtGallery;
 using Streetcode.BLL.Validators.Media.Image.Art;
@@ -48,11 +49,11 @@ public class UpdateStreetcodeValidatorTests
     public async Task ShouldReturnSuccessResult_WhenAllFieldsAreValid()
     {
         // Arrange
-        var streetcode = GetValidStreetcodeUpdateDTO();
+        var command = GetValidUpdateStreetcodeCommand();
         SetupRepositoryWrapperForValidScenario();
 
         // Act
-        var result = await _validator.ValidateAsync(streetcode);
+        var result = await _validator.ValidateAsync(command);
 
         // Assert
         Assert.True(result.IsValid);
@@ -63,12 +64,12 @@ public class UpdateStreetcodeValidatorTests
     public async Task ShouldReturnError_WhenIndexIsNotUnique()
     {
         // Arrange
-        var streetcode = GetValidStreetcodeUpdateDTO();
+        var command = GetValidUpdateStreetcodeCommand();
         SetupRepositoryWrapper(2);
         var expectedMessage = "Index must be unique.";
 
         // Act
-        var result = await _validator.ValidateAsync(streetcode);
+        var result = await _validator.ValidateAsync(command);
 
         // Assert
         Assert.False(result.IsValid);
@@ -79,11 +80,11 @@ public class UpdateStreetcodeValidatorTests
     public async Task ShouldCallBaseValidator()
     {
         // Arrange
-        var streetcode = GetValidStreetcodeUpdateDTO();
+        var command = GetValidUpdateStreetcodeCommand();
         SetupRepositoryWrapperForValidScenario();
 
         // Act
-        await _validator.ValidateAsync(streetcode);
+        await _validator.ValidateAsync(command);
 
         // Assert
         _mockBaseStreetcodeValidator.Verify(v => v.ValidateAsync(It.IsAny<ValidationContext<StreetcodeCreateUpdateDTO>>(), default), Times.Once);
@@ -93,11 +94,11 @@ public class UpdateStreetcodeValidatorTests
     public async Task ShouldCallChildValidators()
     {
         // Arrange
-        var streetcode = GetValidStreetcodeUpdateDTO();
+        var command = GetValidUpdateStreetcodeCommand();
         SetupRepositoryWrapperForValidScenario();
 
         // Act
-        await _validator.ValidateAsync(streetcode);
+        await _validator.ValidateAsync(command);
 
         // Assert
         _mockTagValidator.Verify(v => v.ValidateAsync(It.IsAny<ValidationContext<CreateTagDTO>>(), default), Times.AtLeast(1));
@@ -119,9 +120,9 @@ public class UpdateStreetcodeValidatorTests
             .ReturnsAsync(new StreetcodeContent { Id = id });
     }
 
-    private static StreetcodeUpdateDTO GetValidStreetcodeUpdateDTO()
+    private static UpdateStreetcodeCommand GetValidUpdateStreetcodeCommand()
     {
-        return new StreetcodeUpdateDTO
+        return new UpdateStreetcodeCommand(new StreetcodeUpdateDTO
         {
             Index = 1,
             FirstName = "Ivan",
@@ -147,6 +148,6 @@ public class UpdateStreetcodeValidatorTests
                     Alt = "1",
                 },
             ]
-        };
+        });
     }
 }


### PR DESCRIPTION
dev

## Code reviewers

- [ ] @weazy12
- [ ] @Markian-Grybok 

## Summary of issue

[Validation pipeline] Inconsistent FluentValidation integration with MediatR pipeline
[#125](https://github.com/project-studying-dotnet/Streetcode-Server-August-2025/issues/125)

## Summary of change

Fixes #125 

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced validation for image details: length limits, uniqueness by image, and existence checks with clearer error messages.
  - Unified, command-based validation across create/update flows for categories and streetcodes, improving consistency.

- Refactor
  - Standardized request property naming and integrated nested validators for related items, improving reliability and maintainability.
  - Minor cleanups that do not affect user-facing behavior.

- Tests
  - Expanded unit test coverage for streetcode and image detail validations, including edge cases and repository-backed scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->