### PR TITLE
Added NewsController. Issue #141

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ BlobStorageTestFolder/
 
 # Extract houses.zip files
 /Streetcode/Streetcode.DAL/data/
+/Streetcode/Streetcode.WebApi/secrets.json

--- a/Streetcode/Streetcode.BLL/DTO/News/NewsDTOWithURLs.cs
+++ b/Streetcode/Streetcode.BLL/DTO/News/NewsDTOWithURLs.cs
@@ -8,12 +8,12 @@ namespace Streetcode.BLL.DTO.News
 {
     public class NewsDTOWithURLs
     {
-        public NewsDTO News { get; set; } = new NewsDTO();
+        public NewsDTO News { get; set; } = new();
 
         public string? PrevNewsUrl { get; set; }
 
         public string? NextNewsUrl { get; set; }
 
-        public RandomNewsDTO? RandomNews { get; set; } = new RandomNewsDTO();
+        public RandomNewsDTO? RandomNews { get; set; } = new();
     }
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Newss/GetAll/GetAllNewsHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Newss/GetAll/GetAllNewsHandler.cs
@@ -29,7 +29,7 @@ namespace Streetcode.BLL.MediatR.Newss.GetAll
         {
             var news = await _repositoryWrapper.NewsRepository.GetAllAsync(
                 include: cat => cat.Include(img => img.Image));
-            if (news == null)
+            if (!news.Any())
             {
                 const string errorMsg = "There are no news in the database";
                 _logger.LogError(request, errorMsg);

--- a/Streetcode/Streetcode.BLL/MediatR/Newss/GetById/GetNewsByIdHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Newss/GetById/GetNewsByIdHandler.cs
@@ -26,17 +26,18 @@ namespace Streetcode.BLL.MediatR.Newss.GetById
 
         public async Task<Result<NewsDTO>> Handle(GetNewsByIdQuery request, CancellationToken cancellationToken)
         {
-            int id = request.id;
-            var newsDTO = _mapper.Map<NewsDTO>(await _repositoryWrapper.NewsRepository.GetFirstOrDefaultAsync(
-                predicate: sc => sc.Id == id,
-                include: scl => scl
-                    .Include(sc => sc.Image)));
-            if(newsDTO is null)
+            var news = await _repositoryWrapper.NewsRepository.GetFirstOrDefaultAsync(
+                predicate: sc => sc.Id == request.id,
+                include: scl => scl.Include(sc => sc.Image));
+
+            if (news is null)
             {
-                string errorMsg = $"No news by entered Id - {id}";
+                string errorMsg = $"No news by entered Id - {request.id}";
                 _logger.LogError(request, errorMsg);
                 return Result.Fail(errorMsg);
             }
+
+            var newsDTO = _mapper.Map<NewsDTO>(news);
 
             if (newsDTO.Image is not null)
             {

--- a/Streetcode/Streetcode.BLL/MediatR/Newss/GetNewsAndLinksByUrl/GetNewsAndLinksByUrlHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Newss/GetNewsAndLinksByUrl/GetNewsAndLinksByUrlHandler.cs
@@ -3,7 +3,6 @@ using FluentResults;
 using MediatR;
 using Streetcode.BLL.DTO.News;
 using Streetcode.BLL.Interfaces.BlobStorage;
-using Streetcode.DAL.Entities.News;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 using Microsoft.EntityFrameworkCore;
 using Streetcode.BLL.Interfaces.Logging;
@@ -26,68 +25,59 @@ namespace Streetcode.BLL.MediatR.Newss.GetNewsAndLinksByUrl
 
         public async Task<Result<NewsDTOWithURLs>> Handle(GetNewsAndLinksByUrlQuery request, CancellationToken cancellationToken)
         {
-            string url = request.url;
-            var newsDTO = _mapper.Map<NewsDTO>(await _repositoryWrapper.NewsRepository.GetFirstOrDefaultAsync(
-                predicate: sc => sc.URL == url,
-                include: scl => scl
-                    .Include(sc => sc.Image)));
+            var newsEntity = await _repositoryWrapper.NewsRepository.GetFirstOrDefaultAsync(
+                predicate: sc => sc.URL == request.url,
+                include: scl => scl.Include(sc => sc.Image));
 
-            if (newsDTO is null)
+            if (newsEntity is null)
             {
-                string errorMsg = $"No news by entered Url - {url}";
+                string errorMsg = $"No news by entered Url - {request.url}";
                 _logger.LogError(request, errorMsg);
                 return Result.Fail(errorMsg);
             }
+
+            var newsDTO = _mapper.Map<NewsDTO>(newsEntity);
 
             if (newsDTO.Image is not null)
             {
                 newsDTO.Image.Base64 = _blobService.FindFileInStorageAsBase64(newsDTO.Image.BlobName);
             }
 
-            var news = (await _repositoryWrapper.NewsRepository.GetAllAsync()).ToList();
-            var newsIndex = news.FindIndex(x => x.Id == newsDTO.Id);
-            string prevNewsLink = null;
-            string nextNewsLink = null;
+            var orderedNews = (await _repositoryWrapper.NewsRepository.GetAllAsync())
+                .Select(n => new { n.Id, n.URL, n.Title })
+                .ToList();
 
-            if(newsIndex != 0)
+            var index = orderedNews.FindIndex(x => x.Id == newsDTO.Id);
+            if (index == -1)
             {
-                prevNewsLink = news[newsIndex - 1].URL;
+                string errorMsg = $"News with Id {newsDTO.Id} not found in ordered list";
+                _logger.LogError(request, errorMsg);
+                return Result.Fail(errorMsg);
             }
 
-            if(newsIndex != news.Count - 1)
+            string? prevNewsLink = index > 0 ? orderedNews[index - 1].URL : null;
+            string? nextNewsLink = index < orderedNews.Count - 1 ? orderedNews[index + 1].URL : null;
+
+            // Random news selection (excluding current)
+            RandomNewsDTO randomNews = new();
+            var candidates = orderedNews.Where(n => n.Id != newsDTO.Id).ToList();
+            if (candidates.Any())
             {
-                nextNewsLink = news[newsIndex + 1].URL;
+                var rnd = new Random();
+                var pick = candidates[rnd.Next(candidates.Count)];
+                randomNews.RandomNewsUrl = pick.URL;
+                randomNews.Title = pick.Title;
             }
 
-            var randomNewsTitleAndLink = new RandomNewsDTO();
-
-            var arrCount = news.Count;
-            if (arrCount > 3)
+            var result = new NewsDTOWithURLs
             {
-                if (newsIndex + 1 == arrCount - 1 || newsIndex == arrCount - 1)
-                {
-                    randomNewsTitleAndLink.RandomNewsUrl = news[newsIndex - 2].URL;
-                    randomNewsTitleAndLink.Title = news[newsIndex - 2].Title;
-                }
-                else
-                {
-                    randomNewsTitleAndLink.RandomNewsUrl = news[arrCount - 1].URL;
-                    randomNewsTitleAndLink.Title = news[arrCount - 1].Title;
-                }
-            }
-            else
-            {
-                randomNewsTitleAndLink.RandomNewsUrl = news[newsIndex].URL;
-                randomNewsTitleAndLink.Title = news[newsIndex].Title;
-            }
+                News = newsDTO,
+                PrevNewsUrl = prevNewsLink,
+                NextNewsUrl = nextNewsLink,
+                RandomNews = randomNews
+            };
 
-            var newsDTOWithUrls = new NewsDTOWithURLs();
-            newsDTOWithUrls.RandomNews = randomNewsTitleAndLink;
-            newsDTOWithUrls.News = newsDTO;
-            newsDTOWithUrls.NextNewsUrl = nextNewsLink;
-            newsDTOWithUrls.PrevNewsUrl = prevNewsLink;
-
-            return Result.Ok(newsDTOWithUrls);
+            return Result.Ok(result);
         }
     }
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Newss/SortedByDateTime/SortedByDateTimeHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Newss/SortedByDateTime/SortedByDateTimeHandler.cs
@@ -27,16 +27,19 @@ namespace Streetcode.BLL.MediatR.Newss.SortedByDateTime
 
         public async Task<Result<List<NewsDTO>>> Handle(SortedByDateTimeQuery request, CancellationToken cancellationToken)
         {
-            var news = await _repositoryWrapper.NewsRepository.GetAllAsync(
-                include: cat => cat.Include(img => img.Image));
-            if (news == null)
+            var news = (await _repositoryWrapper.NewsRepository.GetAllAsync(
+                    include: cat => cat.Include(img => img.Image)))
+                .OrderByDescending(n => n.CreationDate)
+                .ToList();
+
+            if (!news.Any())
             {
                 const string errorMsg = "There are no news in the database";
                 _logger.LogError(request, errorMsg);
                 return Result.Fail(errorMsg);
             }
 
-            var newsDTOs = _mapper.Map<IEnumerable<NewsDTO>>(news).OrderByDescending(x => x.CreationDate).ToList();
+            var newsDTOs = _mapper.Map<List<NewsDTO>>(news);
 
             foreach (var dto in newsDTOs)
             {

--- a/Streetcode/Streetcode.WebApi/Controllers/NewsController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/NewsController.cs
@@ -51,19 +51,23 @@ public class NewsController : BaseApiController
     [HttpGet("{url}")]
     [ProducesResponseType(typeof(NewsDTOWithURLs), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> GetNewsByUrl([FromRoute] string url)
+    public async Task<IActionResult> GetNewsByUrl([FromRoute] string url, CancellationToken ct)
     {
         var query = new GetNewsByUrlQuery(url);
-        var result = await Mediator.Send(query);
+        var result = await Mediator.Send(query, ct);
         return HandleResult(result);
     }
 
     [AuthorizeRoles(UserRole.MainAdministrator, UserRole.Administrator, UserRole.Moderator)]
     [HttpPut]
-    public async Task<IActionResult> UpdateNews([FromBody] NewsDTO newsDto)
+    [ProducesResponseType(typeof(NewsDTO), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> UpdateNews([FromBody] NewsDTO newsDto, CancellationToken ct)
     {
         var command = new UpdateNewsCommand(newsDto);
-        var result = await Mediator.Send(command);
+        var result = await Mediator.Send(command, ct);
         return HandleResult(result);
     }
 
@@ -89,7 +93,7 @@ public class NewsController : BaseApiController
         return HandleResult(result);
     }
 
-    [HttpGet()]
+    [HttpGet]
     [ProducesResponseType(typeof(List<NewsDTO>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> GetNewsSortedByDate(CancellationToken ct)

--- a/Streetcode/Streetcode.WebApi/Controllers/NewsController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/NewsController.cs
@@ -41,6 +41,8 @@ public class NewsController : BaseApiController
     }
 
     [HttpGet("{id:int}")]
+    [ProducesResponseType(typeof(NewsDTO), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> GetNewsById([FromRoute] int id)
     {
         var query = new GetNewsByIdQuery(id);

--- a/Streetcode/Streetcode.WebApi/Controllers/NewsController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/NewsController.cs
@@ -1,4 +1,3 @@
-using FluentResults;
 using Microsoft.AspNetCore.Mvc;
 using Streetcode.BLL.DTO.News;
 using Streetcode.BLL.MediatR.Newss.Create;
@@ -66,10 +65,14 @@ public class NewsController : BaseApiController
 
     [AuthorizeRoles(UserRole.MainAdministrator, UserRole.Administrator)]
     [HttpDelete("{id:int}")]
-    public async Task<IActionResult> DeleteNews([FromRoute] int id)
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> DeleteNews([FromRoute] int id, CancellationToken ct)
     {
         var command = new DeleteNewsCommand(id);
-        var result = await Mediator.Send(command);
+        var result = await Mediator.Send(command, ct);
         return HandleResult(result);
     }
 }

--- a/Streetcode/Streetcode.WebApi/Controllers/NewsController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/NewsController.cs
@@ -6,6 +6,7 @@ using Streetcode.BLL.MediatR.Newss.GetAll;
 using Streetcode.BLL.MediatR.Newss.GetById;
 using Streetcode.BLL.MediatR.Newss.GetByUrl;
 using Streetcode.BLL.MediatR.Newss.GetNewsAndLinksByUrl;
+using Streetcode.BLL.MediatR.Newss.SortedByDateTime;
 using Streetcode.BLL.MediatR.Newss.Update;
 using Streetcode.DAL.Enums;
 using Streetcode.WebApi.Attributes;
@@ -85,6 +86,16 @@ public class NewsController : BaseApiController
     public async Task<IActionResult> GetNewsAndLinksByUrl([FromRoute] string url, CancellationToken ct)
     {
         var result = await Mediator.Send(new GetNewsAndLinksByUrlQuery(url), ct);
+        return HandleResult(result);
+    }
+
+    [HttpGet()]
+    [ProducesResponseType(typeof(List<NewsDTO>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetNewsSortedByDate(CancellationToken ct)
+    {
+        var query = new SortedByDateTimeQuery();
+        var result = await Mediator.Send(query, ct);
         return HandleResult(result);
     }
 }

--- a/Streetcode/Streetcode.WebApi/Controllers/NewsController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/NewsController.cs
@@ -5,16 +5,13 @@ using Streetcode.BLL.MediatR.Newss.Delete;
 using Streetcode.BLL.MediatR.Newss.GetAll;
 using Streetcode.BLL.MediatR.Newss.GetById;
 using Streetcode.BLL.MediatR.Newss.GetByUrl;
+using Streetcode.BLL.MediatR.Newss.GetNewsAndLinksByUrl;
 using Streetcode.BLL.MediatR.Newss.Update;
 using Streetcode.DAL.Enums;
 using Streetcode.WebApi.Attributes;
 
 namespace Streetcode.WebApi.Controllers;
 
-/// <summary>
-/// Not finished controller created for testing purposes
-/// in the future it will be worth refining and rechecking
-/// </summary>
 public class NewsController : BaseApiController
 {
     [AuthorizeRoles(UserRole.MainAdministrator, UserRole.Administrator, UserRole.Moderator)]
@@ -43,14 +40,16 @@ public class NewsController : BaseApiController
     [HttpGet("{id:int}")]
     [ProducesResponseType(typeof(NewsDTO), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public async Task<IActionResult> GetNewsById([FromRoute] int id)
+    public async Task<IActionResult> GetNewsById([FromRoute] int id, CancellationToken ct)
     {
         var query = new GetNewsByIdQuery(id);
-        var result = await Mediator.Send(query);
+        var result = await Mediator.Send(query, ct);
         return HandleResult(result);
     }
 
-    [HttpGet("url/{url}")]
+    [HttpGet("{url}")]
+    [ProducesResponseType(typeof(NewsDTOWithURLs), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> GetNewsByUrl([FromRoute] string url)
     {
         var query = new GetNewsByUrlQuery(url);
@@ -77,6 +76,15 @@ public class NewsController : BaseApiController
     {
         var command = new DeleteNewsCommand(id);
         var result = await Mediator.Send(command, ct);
+        return HandleResult(result);
+    }
+
+    [HttpGet("{url}")]
+    [ProducesResponseType(typeof(NewsDTOWithURLs), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetNewsAndLinksByUrl([FromRoute] string url, CancellationToken ct)
+    {
+        var result = await Mediator.Send(new GetNewsAndLinksByUrlQuery(url), ct);
         return HandleResult(result);
     }
 }

--- a/Streetcode/Streetcode.WebApi/Controllers/NewsController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/NewsController.cs
@@ -31,10 +31,12 @@ public class NewsController : BaseApiController
     }
 
     [HttpGet]
-    public async Task<IActionResult> GetAllNews()
+    [ProducesResponseType(typeof(IEnumerable<NewsDTO>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetAllNews(CancellationToken ct)
     {
         var query = new GetAllNewsQuery();
-        var result = await Mediator.Send(query);
+        var result = await Mediator.Send(query, ct);
         return HandleResult(result);
     }
 

--- a/Streetcode/Streetcode.WebApi/Controllers/NewsController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/NewsController.cs
@@ -20,10 +20,14 @@ public class NewsController : BaseApiController
 {
     [AuthorizeRoles(UserRole.MainAdministrator, UserRole.Administrator, UserRole.Moderator)]
     [HttpPost]
-    public async Task<IActionResult> CreateNews([FromBody] NewsDTO newsDto)
+    [ProducesResponseType(typeof(NewsDTO), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> CreateNews([FromBody] NewsDTO newsDto, CancellationToken ct)
     {
         var command = new CreateNewsCommand(newsDto);
-        var result = await Mediator.Send(command);
+        var result = await Mediator.Send(command, ct);
         return HandleResult(result);
     }
 

--- a/Streetcode/Streetcode.XUnitTest/BLL/MediatR/News/GetAllNewsTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/MediatR/News/GetAllNewsTests.cs
@@ -127,7 +127,7 @@ public class GetAllNewsTests
     }
 
     [Fact]
-    public async Task GetAllNews_WhenRepositoryReturnsNull_ShouldReturnFailure()
+    public async Task GetAllNews_WhenRepositoryReturnsEmptyCollection_ShouldReturnFailure()
     {
         // Arrange
         _mockNewsRepository
@@ -135,7 +135,7 @@ public class GetAllNewsTests
                 It.IsAny<Expression<Func<DAL.Entities.News.News, bool>>>(),
                 It.IsAny<Func<IQueryable<DAL.Entities.News.News>,
                     IIncludableQueryable<DAL.Entities.News.News, object>>>()))
-            .ReturnsAsync((IEnumerable<DAL.Entities.News.News>)null);
+            .ReturnsAsync(new List<DAL.Entities.News.News>());
 
         var query = new GetAllNewsQuery();
 

--- a/Streetcode/Streetcode.XUnitTest/BLL/MediatR/News/GetNewsByIdTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/MediatR/News/GetNewsByIdTests.cs
@@ -83,11 +83,7 @@ public class GetNewsByIdTests
             .Setup(r => r.GetFirstOrDefaultAsync(
                 It.IsAny<Expression<Func<DAL.Entities.News.News, bool>>>(),
                 It.IsAny<Func<IQueryable<DAL.Entities.News.News>, IIncludableQueryable<DAL.Entities.News.News, object>>>()))
-            .ReturnsAsync(newsEntity);
-
-        _mockMapper
-            .Setup(m => m.Map<NewsDTO>(newsEntity))
-            .Returns((NewsDTO)null);
+            .ReturnsAsync((DAL.Entities.News.News)null);
 
         var query = new GetNewsByIdQuery(newsId);
 
@@ -98,8 +94,6 @@ public class GetNewsByIdTests
         result.Should().NotBeNull();
         result.IsSuccess.Should().BeFalse();
         result.Errors.Should().NotBeEmpty();
-
-        _mockMapper.Verify(m => m.Map<NewsDTO>(newsEntity), Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
dev

- [ ] @
- [ ] @
- [ ] @

## Summary of issue

Issues:
- https://github.com/project-studying-dotnet/Streetcode-Server-August-2025/issues/141 - [Task][User/Authentication] Create Jwt service

## Summary of change

Added and refined news endpoints with consistent result handling and documentation.

## Changes introduced

- Implemented CreateNews, UpdateNews, GetAllNews, and GetNewsAndLinksByUrl endpoints in NewsController.
- Integrated cancellation tokens and standardized HandleResult usage across endpoints.
- Added [ProducesResponseType] annotations for consistent API documentation.


## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions
