### PR TITLE
Added user registartion and RevokeRefreshToken. Issue #85

### DIFF
--- a/Streetcode/Streetcode.BLL/DTO/Users/RegisterUserDTO.cs
+++ b/Streetcode/Streetcode.BLL/DTO/Users/RegisterUserDTO.cs
@@ -1,0 +1,11 @@
+﻿namespace Streetcode.BLL.DTO.Users;
+
+public class RegisterUserDTO
+{
+    public string? Name { get; set; }
+    public string? Surname { get; set; }
+    public string? UserName { get; set; }
+    public string Password { get; set; }
+    public string Email { get; set; }
+    public string? PhoneNumber { get; set; }
+}

--- a/Streetcode/Streetcode.BLL/DTO/Users/RegisterUserDTO.cs
+++ b/Streetcode/Streetcode.BLL/DTO/Users/RegisterUserDTO.cs
@@ -5,7 +5,7 @@ public class RegisterUserDTO
     public string? Name { get; set; }
     public string? Surname { get; set; }
     public string? UserName { get; set; }
-    public required string Password { get; set; }
-    public required string Email { get; set; }
+    public string Password { get; set; }
+    public string Email { get; set; }
     public string? PhoneNumber { get; set; }
 }

--- a/Streetcode/Streetcode.BLL/DTO/Users/RegisterUserDTO.cs
+++ b/Streetcode/Streetcode.BLL/DTO/Users/RegisterUserDTO.cs
@@ -5,7 +5,7 @@ public class RegisterUserDTO
     public string? Name { get; set; }
     public string? Surname { get; set; }
     public string? UserName { get; set; }
-    public string Password { get; set; }
-    public string Email { get; set; }
+    public required string Password { get; set; }
+    public required string Email { get; set; }
     public string? PhoneNumber { get; set; }
 }

--- a/Streetcode/Streetcode.BLL/DTO/Users/RegisterUserResponseDTO.cs
+++ b/Streetcode/Streetcode.BLL/DTO/Users/RegisterUserResponseDTO.cs
@@ -1,0 +1,14 @@
+﻿using Streetcode.DAL.Enums;
+
+namespace Streetcode.BLL.DTO.Users;
+
+public class RegisterUserResponseDTO
+{
+    public int Id { get; set; }
+    public string UserName { get; set; } = null!;
+    public string Email { get; set; } = null!;
+    public string? Name { get; set; }
+    public string? Surname { get; set; }
+    public string? PhoneNumber { get; set; }
+    public UserRole Role { get; set; }
+}

--- a/Streetcode/Streetcode.BLL/Interfaces/Jwt/IJwtTokenService.cs
+++ b/Streetcode/Streetcode.BLL/Interfaces/Jwt/IJwtTokenService.cs
@@ -11,4 +11,5 @@ public interface IJwtTokenService
     Result<ClaimsPrincipal> ValidateToken(string token);
     Result<int> GetUserIdFromToken(string token);
     Task<Result<LoginResultDTO>> RefreshTokenAsync(string token, string refreshToken);
+    Task<Result> RevokeRefreshTokenAsync(int userId);
 }

--- a/Streetcode/Streetcode.BLL/Mapping/Users/UserProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Users/UserProfile.cs
@@ -12,6 +12,7 @@ namespace Streetcode.BLL.Mapping.Users
             CreateMap<UserDTO, UserLoginDTO>().ReverseMap();
             CreateMap<User, UserDTO>().ReverseMap();
             CreateMap<User, RegisterUserDTO>().ReverseMap();
+            CreateMap<User, RegisterUserResponseDTO>().ReverseMap();
         }
     }
 }

--- a/Streetcode/Streetcode.BLL/Mapping/Users/UserProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/Users/UserProfile.cs
@@ -11,6 +11,7 @@ namespace Streetcode.BLL.Mapping.Users
             CreateMap<User, UserLoginDTO>().ReverseMap();
             CreateMap<UserDTO, UserLoginDTO>().ReverseMap();
             CreateMap<User, UserDTO>().ReverseMap();
+            CreateMap<User, RegisterUserDTO>().ReverseMap();
         }
     }
 }

--- a/Streetcode/Streetcode.BLL/MediatR/Users/Register/RegisterUserCommand.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Users/Register/RegisterUserCommand.cs
@@ -4,4 +4,4 @@ using Streetcode.BLL.DTO.Users;
 
 namespace Streetcode.BLL.MediatR.Users.Register;
 
-public record RegisterUserCommand(RegisterUserDTO Dto) : IRequest<Result<RegisterUserResponseDTO>>;
+public record RegisterUserCommand(RegisterUserDTO registeredUserDto) : IRequest<Result<RegisterUserResponseDTO>>;

--- a/Streetcode/Streetcode.BLL/MediatR/Users/Register/RegisterUserCommand.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Users/Register/RegisterUserCommand.cs
@@ -1,0 +1,7 @@
+﻿using FluentResults;
+using MediatR;
+using Streetcode.BLL.DTO.Users;
+
+namespace Streetcode.BLL.MediatR.Users.Register;
+
+public record RegisterUserCommand(RegisterUserDTO Dto) : IRequest<Result<RegisterUserResponseDTO>>;

--- a/Streetcode/Streetcode.BLL/MediatR/Users/Register/RegisterUserHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Users/Register/RegisterUserHandler.cs
@@ -1,14 +1,17 @@
 ﻿using AutoMapper;
 using FluentResults;
+using MediatR;
 using Microsoft.AspNetCore.Identity;
+using Streetcode.BLL.DTO.News;
 using Streetcode.BLL.DTO.Users;
+using Streetcode.BLL.MediatR.Newss.Update;
 using Streetcode.DAL.Entities.Users;
 using Streetcode.DAL.Enums;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 
 namespace Streetcode.BLL.MediatR.Users.Register;
 
-public class RegisterUserHandler
+public class RegisterUserHandler : IRequestHandler<RegisterUserCommand, Result<RegisterUserResponseDTO>>
 {
     private readonly UserManager<User> _userManager;
     private readonly IMapper _mapper;
@@ -40,7 +43,7 @@ public class RegisterUserHandler
         user.Role = UserRole.User;
         user.EmailConfirmed = false;
 
-        var createResult = await _userManager.CreateAsync(user);
+        var createResult = await _userManager.CreateAsync(user, request.registeredUserDto.Password);
         if (!createResult.Succeeded)
         {
             var errors = string.Join("; ", createResult.Errors.Select(e => e.Description));

--- a/Streetcode/Streetcode.BLL/MediatR/Users/Register/RegisterUserHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Users/Register/RegisterUserHandler.cs
@@ -2,9 +2,7 @@
 using FluentResults;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
-using Streetcode.BLL.DTO.News;
 using Streetcode.BLL.DTO.Users;
-using Streetcode.BLL.MediatR.Newss.Update;
 using Streetcode.DAL.Entities.Users;
 using Streetcode.DAL.Enums;
 using Streetcode.DAL.Repositories.Interfaces.Base;
@@ -16,7 +14,6 @@ public class RegisterUserHandler : IRequestHandler<RegisterUserCommand, Result<R
     private readonly UserManager<User> _userManager;
     private readonly IMapper _mapper;
     private readonly IRepositoryWrapper _repositoryWrapper;
-
 
     public RegisterUserHandler(UserManager<User> userManager, IMapper mapper, IRepositoryWrapper repositoryWrapper)
     {
@@ -60,7 +57,8 @@ public class RegisterUserHandler : IRequestHandler<RegisterUserCommand, Result<R
 
             var response = _mapper.Map<RegisterUserResponseDTO>(user);
             return Result.Ok(response);
-        }catch (Exception ex)
+        }
+        catch (Exception ex)
         {
             return Result.Fail<RegisterUserResponseDTO>(new ExceptionalError(ex));
         }
@@ -69,11 +67,15 @@ public class RegisterUserHandler : IRequestHandler<RegisterUserCommand, Result<R
     public static Result<string> GetUserNameFromEmail(string email)
     {
         if (string.IsNullOrWhiteSpace(email))
+        {
             return Result.Fail<string>("Email cannot be null or empty.");
+        }
 
         var atIndex = email.IndexOf('@');
         if (atIndex <= 0)
+        {
             return Result.Fail<string>("Invalid email format.");
+        }
 
         return Result.Ok(email.Substring(0, atIndex));
     }

--- a/Streetcode/Streetcode.BLL/MediatR/Users/Register/RegisterUserHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Users/Register/RegisterUserHandler.cs
@@ -27,43 +27,55 @@ public class RegisterUserHandler : IRequestHandler<RegisterUserCommand, Result<R
 
     public async Task<Result<RegisterUserResponseDTO>> Handle(RegisterUserCommand request, CancellationToken cancellationToken)
     {
-        var user = _mapper.Map<User>(request.registeredUserDto);
-
-        if (string.IsNullOrWhiteSpace(user.UserName))
+        try
         {
-            user.UserName = GetUserNameFromEmail(user.Email);
-        }
+            var user = _mapper.Map<User>(request.registeredUserDto);
 
-        var uniquenessResult = await EnsureUserDoesNotExistAsync(user, cancellationToken);
-        if (uniquenessResult.IsFailed)
+            if (string.IsNullOrWhiteSpace(user.UserName))
+            {
+                var userNameResult = GetUserNameFromEmail(user.Email);
+                if (userNameResult.IsFailed)
+                {
+                    return Result.Fail<RegisterUserResponseDTO>(userNameResult.Errors.First().Message);
+                }
+
+                user.UserName = userNameResult.Value;
+            }
+
+            var uniquenessResult = await EnsureUserDoesNotExistAsync(user, cancellationToken);
+            if (uniquenessResult.IsFailed)
+            {
+                return Result.Fail<RegisterUserResponseDTO>(uniquenessResult.Errors.First().Message);
+            }
+
+            user.Role = UserRole.User;
+            user.EmailConfirmed = false;
+
+            var createResult = await _userManager.CreateAsync(user, request.registeredUserDto.Password);
+            if (!createResult.Succeeded)
+            {
+                var errors = string.Join("; ", createResult.Errors.Select(e => e.Description));
+                return Result.Fail<RegisterUserResponseDTO>(errors);
+            }
+
+            var response = _mapper.Map<RegisterUserResponseDTO>(user);
+            return Result.Ok(response);
+        }catch (Exception ex)
         {
-            return Result.Fail<RegisterUserResponseDTO>(uniquenessResult.Errors.First().Message);
+            return Result.Fail<RegisterUserResponseDTO>(new ExceptionalError(ex));
         }
-
-        user.Role = UserRole.User;
-        user.EmailConfirmed = false;
-
-        var createResult = await _userManager.CreateAsync(user, request.registeredUserDto.Password);
-        if (!createResult.Succeeded)
-        {
-            var errors = string.Join("; ", createResult.Errors.Select(e => e.Description));
-            return Result.Fail<RegisterUserResponseDTO>(errors);
-        }
-
-        var response = _mapper.Map<RegisterUserResponseDTO>(user);
-        return Result.Ok(response);
     }
 
-    public static string GetUserNameFromEmail(string email)
+    public static Result<string> GetUserNameFromEmail(string email)
     {
         if (string.IsNullOrWhiteSpace(email))
-            throw new ArgumentException("Email cannot be null or empty.", nameof(email));
+            return Result.Fail<string>("Email cannot be null or empty.");
 
         var atIndex = email.IndexOf('@');
         if (atIndex <= 0)
-            throw new ArgumentException("Invalid email format.", nameof(email));
+            return Result.Fail<string>("Invalid email format.");
 
-        return email.Substring(0, atIndex);
+        return Result.Ok(email.Substring(0, atIndex));
     }
 
     private async Task<Result> EnsureUserDoesNotExistAsync(User user, CancellationToken cancellationToken)

--- a/Streetcode/Streetcode.BLL/MediatR/Users/Register/RegisterUserHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/Users/Register/RegisterUserHandler.cs
@@ -1,0 +1,79 @@
+﻿using AutoMapper;
+using FluentResults;
+using Microsoft.AspNetCore.Identity;
+using Streetcode.BLL.DTO.Users;
+using Streetcode.DAL.Entities.Users;
+using Streetcode.DAL.Enums;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+
+namespace Streetcode.BLL.MediatR.Users.Register;
+
+public class RegisterUserHandler
+{
+    private readonly UserManager<User> _userManager;
+    private readonly IMapper _mapper;
+    private readonly IRepositoryWrapper _repositoryWrapper;
+
+
+    public RegisterUserHandler(UserManager<User> userManager, IMapper mapper, IRepositoryWrapper repositoryWrapper)
+    {
+        _userManager = userManager;
+        _mapper = mapper;
+        _repositoryWrapper = repositoryWrapper;
+    }
+
+    public async Task<Result<RegisterUserResponseDTO>> Handle(RegisterUserCommand request, CancellationToken cancellationToken)
+    {
+        var user = _mapper.Map<User>(request.registeredUserDto);
+
+        if (string.IsNullOrWhiteSpace(user.UserName))
+        {
+            user.UserName = GetUserNameFromEmail(user.Email);
+        }
+
+        var uniquenessResult = await EnsureUserDoesNotExistAsync(user, cancellationToken);
+        if (uniquenessResult.IsFailed)
+        {
+            return Result.Fail<RegisterUserResponseDTO>(uniquenessResult.Errors.First().Message);
+        }
+
+        user.Role = UserRole.User;
+        user.EmailConfirmed = false;
+
+        var createResult = await _userManager.CreateAsync(user);
+        if (!createResult.Succeeded)
+        {
+            var errors = string.Join("; ", createResult.Errors.Select(e => e.Description));
+            return Result.Fail<RegisterUserResponseDTO>(errors);
+        }
+
+        var response = _mapper.Map<RegisterUserResponseDTO>(user);
+        return Result.Ok(response);
+    }
+
+    public static string GetUserNameFromEmail(string email)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+            throw new ArgumentException("Email cannot be null or empty.", nameof(email));
+
+        var atIndex = email.IndexOf('@');
+        if (atIndex <= 0)
+            throw new ArgumentException("Invalid email format.", nameof(email));
+
+        return email.Substring(0, atIndex);
+    }
+
+    private async Task<Result> EnsureUserDoesNotExistAsync(User user, CancellationToken cancellationToken)
+    {
+        var existingUser = await _repositoryWrapper.UserRepository
+            .GetFirstOrDefaultAsync(
+                predicate: u => u.Email == user.Email || u.UserName == user.UserName);
+
+        if (existingUser is not null)
+        {
+            return Result.Fail("User with this email or username already exists");
+        }
+
+        return Result.Ok();
+    }
+}

--- a/Streetcode/Streetcode.BLL/Services/JwtTokenService/JwtTokenService.cs
+++ b/Streetcode/Streetcode.BLL/Services/JwtTokenService/JwtTokenService.cs
@@ -172,7 +172,7 @@ public class JwtTokenService : IJwtTokenService
 
         if (user.RefreshToken != refreshToken)
         {
-            return Result.Fail<LoginResultDTO>("Refresh token does not match");
+            return Result.Fail<LoginResultDTO>("Refresh token does not match or was revoked");
         }
 
         if (user.RefreshTokenExpiryTime is null || user.RefreshTokenExpiryTime <= DateTime.UtcNow)
@@ -219,6 +219,30 @@ public class JwtTokenService : IJwtTokenService
         using var rng = RandomNumberGenerator.Create();
         rng.GetBytes(randomNumber);
         return Convert.ToBase64String(randomNumber);
+    }
+
+    public async Task<Result> RevokeRefreshTokenAsync(int userId)
+    {
+        var user = await _repositoryWrapper.UserRepository
+            .GetFirstOrDefaultAsync(u => u.Id == userId);
+
+        if (user is null)
+        {
+            return Result.Fail("User not found");
+        }
+
+        if (user.RefreshToken is null)
+        {
+            return Result.Fail("User does not have an active refresh token");
+        }
+
+        user.RefreshToken = null;
+        user.RefreshTokenExpiryTime = null;
+
+        _repositoryWrapper.UserRepository.Update(user);
+        await _repositoryWrapper.SaveChangesAsync();
+
+        return Result.Ok();
     }
 
     private Result<ClaimsPrincipal> GetPrincipalFromExpiredToken(string token)

--- a/Streetcode/Streetcode.BLL/Services/JwtTokenService/JwtTokenService.cs
+++ b/Streetcode/Streetcode.BLL/Services/JwtTokenService/JwtTokenService.cs
@@ -231,11 +231,6 @@ public class JwtTokenService : IJwtTokenService
             return Result.Fail("User not found");
         }
 
-        if (user.RefreshToken is null)
-        {
-            return Result.Fail("User does not have an active refresh token");
-        }
-
         user.RefreshToken = null;
         user.RefreshTokenExpiryTime = null;
 

--- a/Streetcode/Streetcode.BLL/Services/JwtTokenService/JwtTokenService.cs
+++ b/Streetcode/Streetcode.BLL/Services/JwtTokenService/JwtTokenService.cs
@@ -223,21 +223,28 @@ public class JwtTokenService : IJwtTokenService
 
     public async Task<Result> RevokeRefreshTokenAsync(int userId)
     {
-        var user = await _repositoryWrapper.UserRepository
-            .GetFirstOrDefaultAsync(u => u.Id == userId);
-
-        if (user is null)
+        try
         {
-            return Result.Fail("User not found");
+            var user = await _repositoryWrapper.UserRepository
+                .GetFirstOrDefaultAsync(u => u.Id == userId);
+
+            if (user is null)
+            {
+                return Result.Fail("User not found");
+            }
+
+            user.RefreshToken = null;
+            user.RefreshTokenExpiryTime = null;
+
+            _repositoryWrapper.UserRepository.Update(user);
+            await _repositoryWrapper.SaveChangesAsync();
+
+            return Result.Ok();
         }
-
-        user.RefreshToken = null;
-        user.RefreshTokenExpiryTime = null;
-
-        _repositoryWrapper.UserRepository.Update(user);
-        await _repositoryWrapper.SaveChangesAsync();
-
-        return Result.Ok();
+        catch (Exception ex)
+        {
+            return Result.Fail(new ExceptionalError(ex));
+        }
     }
 
     private Result<ClaimsPrincipal> GetPrincipalFromExpiredToken(string token)

--- a/Streetcode/Streetcode.BLL/Streetcode.BLL.csproj
+++ b/Streetcode/Streetcode.BLL/Streetcode.BLL.csproj
@@ -50,6 +50,7 @@
     <Folder Include="MediatR\AdditionalContent\Tag\" />
     <Folder Include="Exceptions\" />
     <Folder Include="DTO\Instagram\" />
+    <Folder Include="MediatR\Users\Register\" />
     <Folder Include="Validators\Email\" />
     <Folder Include="Validators\Helpers\" />
     <Folder Include="Validators\Payment\" />

--- a/Streetcode/Streetcode.BLL/Validators/Users/RegisterUserCommandValidator.cs
+++ b/Streetcode/Streetcode.BLL/Validators/Users/RegisterUserCommandValidator.cs
@@ -1,0 +1,22 @@
+﻿using FluentValidation;
+using Streetcode.BLL.MediatR.Users.Register;
+using Streetcode.BLL.Resources;
+using Streetcode.BLL.Util.Extensions;
+
+namespace Streetcode.BLL.Validators.Users;
+
+public class RegisterUserCommandValidator : AbstractValidator<RegisterUserCommand>
+{
+    public RegisterUserCommandValidator()
+    {
+        RuleFor(x => x.registeredUserDto)
+            .NotNull()
+            .WithMessage(Errors_Validation.IsRequiredData.FormatWith("RegisteredUserDto"));
+
+        When(x => x.registeredUserDto != null, () =>
+        {
+            RuleFor(x => x.registeredUserDto)
+                .SetValidator(new RegisterUserDTOValidator());
+        });
+    }
+}

--- a/Streetcode/Streetcode.BLL/Validators/Users/RegisterUserDTOValidator.cs
+++ b/Streetcode/Streetcode.BLL/Validators/Users/RegisterUserDTOValidator.cs
@@ -10,14 +10,28 @@ public class RegisterUserDTOValidator : AbstractValidator<RegisterUserDTO>
     {
         RuleFor(x => x.Email)
             .NotEmpty().WithMessage("Email is required")
-            .EmailAddress().WithMessage("Invalid email format");
+            .EmailAddress().WithMessage("Invalid email format")
+            .MaximumLength(50).WithMessage("Email must not exceed 50 characters");
 
         RuleFor(x => x.Password)
             .NotEmpty().WithMessage("Password is required")
             .MinimumLength(MinPasswordLength).WithMessage($"Password must be at least {MinPasswordLength} characters long")
+            .MaximumLength(20).WithMessage("Password must not exceed 20 characters")
             .Matches("[A-Z]").WithMessage("Password must contain at least one uppercase letter")
             .Matches("[a-z]").WithMessage("Password must contain at least one lowercase letter")
             .Matches("[0-9]").WithMessage("Password must contain at least one digit");
+
+        RuleFor(x => x.UserName)
+            .MaximumLength(20).WithMessage("UserName must not exceed 20 characters")
+            .When(x => !string.IsNullOrWhiteSpace(x.UserName));
+
+        RuleFor(x => x.Name)
+            .MaximumLength(50).WithMessage("Name must not exceed 50 characters")
+            .When(x => !string.IsNullOrWhiteSpace(x.Name));
+
+        RuleFor(x => x.Surname)
+            .MaximumLength(50).WithMessage("Surname must not exceed 50 characters")
+            .When(x => !string.IsNullOrWhiteSpace(x.Surname));
 
         RuleFor(x => x.PhoneNumber)
             .Matches(@"^\+?\d{10,15}$")

--- a/Streetcode/Streetcode.BLL/Validators/Users/RegisterUserDTOValidator.cs
+++ b/Streetcode/Streetcode.BLL/Validators/Users/RegisterUserDTOValidator.cs
@@ -1,0 +1,27 @@
+﻿using FluentValidation;
+using Streetcode.BLL.DTO.Users;
+
+namespace Streetcode.BLL.Validators.Users;
+
+public class RegisterUserDTOValidator : AbstractValidator<RegisterUserDTO>
+{
+    public const int MinPasswordLength = 6;
+    public RegisterUserDTOValidator()
+    {
+        RuleFor(x => x.Email)
+            .NotEmpty().WithMessage("Email is required")
+            .EmailAddress().WithMessage("Invalid email format");
+
+        RuleFor(x => x.Password)
+            .NotEmpty().WithMessage("Password is required")
+            .MinimumLength(MinPasswordLength).WithMessage($"Password must be at least {MinPasswordLength} characters long")
+            .Matches("[A-Z]").WithMessage("Password must contain at least one uppercase letter")
+            .Matches("[a-z]").WithMessage("Password must contain at least one lowercase letter")
+            .Matches("[0-9]").WithMessage("Password must contain at least one digit");
+
+        RuleFor(x => x.PhoneNumber)
+            .Matches(@"^\+?\d{10,15}$")
+            .When(x => !string.IsNullOrWhiteSpace(x.PhoneNumber))
+            .WithMessage("Invalid phone number format");
+    }
+}

--- a/Streetcode/Streetcode.WebApi/Controllers/Auth/AuthController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/Auth/AuthController.cs
@@ -1,0 +1,26 @@
+﻿using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Streetcode.BLL.DTO.Users;
+using Streetcode.BLL.MediatR.Users.Register;
+
+namespace Streetcode.WebApi.Controllers.Auth
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class AuthController : BaseApiController
+    {
+        [HttpPost("register")]
+        public async Task<ActionResult<RegisterUserResponseDTO>> Register([FromBody] RegisterUserDTO dto, CancellationToken ct)
+        {
+            var result = await Mediator.Send(new RegisterUserCommand(dto), ct);
+
+            if (result.IsFailed)
+            {
+                return BadRequest(result.Errors.Select(e => e.Message));
+            }
+
+            return Ok(result.Value);
+        }
+    }
+}

--- a/Streetcode/Streetcode.WebApi/Streetcode.WebApi.csproj
+++ b/Streetcode/Streetcode.WebApi/Streetcode.WebApi.csproj
@@ -66,7 +66,6 @@
 
   <ItemGroup>
     <Folder Include="Controllers\Analytics\" />
-    <Folder Include="Controllers\User\" />
   </ItemGroup>
 
 </Project>

--- a/Streetcode/Streetcode.XUnitTest/BLL/MediatR/Users/RegisterUserTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/MediatR/Users/RegisterUserTests.cs
@@ -1,4 +1,5 @@
-﻿using AutoMapper;
+﻿using System.Linq.Expressions;
+using AutoMapper;
 using FluentResults;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore.Query;
@@ -9,7 +10,6 @@ using Streetcode.DAL.Entities.Users;
 using Streetcode.DAL.Enums;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 using Streetcode.DAL.Repositories.Interfaces.Users;
-using System.Linq.Expressions;
 using Xunit;
 
 namespace Streetcode.XUnitTest.BLL.MediatR.Users;
@@ -278,5 +278,4 @@ public class RegisterUserTests
         Assert.True(result.IsFailed);
         Assert.Equal("Invalid email format.", result.Errors.First().Message);
     }
-
 }

--- a/Streetcode/Streetcode.XUnitTest/BLL/MediatR/Users/RegisterUserTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/MediatR/Users/RegisterUserTests.cs
@@ -1,0 +1,282 @@
+﻿using AutoMapper;
+using FluentResults;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore.Query;
+using Moq;
+using Streetcode.BLL.DTO.Users;
+using Streetcode.BLL.MediatR.Users.Register;
+using Streetcode.DAL.Entities.Users;
+using Streetcode.DAL.Enums;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using Streetcode.DAL.Repositories.Interfaces.Users;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace Streetcode.XUnitTest.BLL.MediatR.Users;
+
+public class RegisterUserTests
+{
+    private readonly Mock<UserManager<User>> _userManagerMock;
+    private readonly Mock<IMapper> _mapperMock;
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
+    private readonly Mock<IUserRepository> _userRepositoryMock;
+    private readonly RegisterUserHandler _handler;
+    private readonly CancellationToken _cancellationToken = CancellationToken.None;
+
+    public RegisterUserTests()
+    {
+        // Setup UserManager mock
+        var store = new Mock<IUserStore<User>>();
+        _userManagerMock = new Mock<UserManager<User>>(store.Object, null, null, null, null, null, null, null, null);
+
+        _mapperMock = new Mock<IMapper>();
+        _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
+        _userRepositoryMock = new Mock<IUserRepository>();
+
+        _repositoryWrapperMock.Setup(x => x.UserRepository).Returns(_userRepositoryMock.Object);
+
+        _handler = new RegisterUserHandler(_userManagerMock.Object, _mapperMock.Object, _repositoryWrapperMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_ReturnsSuccessResult()
+    {
+        // Arrange
+        var registerUserDto = new RegisterUserDTO
+        {
+            Email = "test@example.com",
+            Password = "Password123",
+            UserName = "testuser",
+            Name = "Test",
+            Surname = "User"
+        };
+
+        var command = new RegisterUserCommand(registerUserDto);
+        var user = new User
+        {
+            Email = "test@example.com",
+            UserName = "testuser",
+            Name = "Test",
+            Surname = "User"
+        };
+
+        var responseDto = new RegisterUserResponseDTO
+        {
+            Id = 1,
+            Email = "test@example.com",
+            UserName = "testuser"
+        };
+
+        _mapperMock.Setup(m => m.Map<User>(registerUserDto)).Returns(user);
+        _userRepositoryMock.Setup(r => r.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<User, bool>>>(),
+                It.IsAny<Func<IQueryable<User>, IIncludableQueryable<User, object>>>()))
+            .ReturnsAsync((User)null);
+
+        _userManagerMock.Setup(um => um.CreateAsync(user, registerUserDto.Password))
+            .ReturnsAsync(IdentityResult.Success);
+        _mapperMock.Setup(m => m.Map<RegisterUserResponseDTO>(user)).Returns(responseDto);
+
+        // Act
+        var result = await _handler.Handle(command, _cancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(result.Value);
+        Assert.Equal(responseDto.Email, result.Value.Email);
+        Assert.Equal(UserRole.User, user.Role);
+        Assert.False(user.EmailConfirmed);
+    }
+
+    [Fact]
+    public async Task Handle_UserNameIsEmpty_GeneratesUserNameFromEmail()
+    {
+        // Arrange
+        var registerUserDto = new RegisterUserDTO
+        {
+            Email = "test@example.com",
+            Password = "Password123",
+            UserName = "",
+            Name = "Test",
+            Surname = "User"
+        };
+
+        var command = new RegisterUserCommand(registerUserDto);
+        var user = new User
+        {
+            Email = "test@example.com",
+            UserName = "",
+            Name = "Test",
+            Surname = "User"
+        };
+
+        var responseDto = new RegisterUserResponseDTO
+        {
+            Id = 1,
+            Email = "test@example.com",
+            UserName = "test"
+        };
+
+        _mapperMock.Setup(m => m.Map<User>(registerUserDto)).Returns(user);
+        _userRepositoryMock.Setup(r => r.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<User, bool>>>(),
+                It.IsAny<Func<IQueryable<User>, IIncludableQueryable<User, object>>>()))
+            .ReturnsAsync((User)null);
+        _userManagerMock.Setup(um => um.CreateAsync(It.IsAny<User>(), registerUserDto.Password))
+            .ReturnsAsync(IdentityResult.Success);
+        _mapperMock.Setup(m => m.Map<RegisterUserResponseDTO>(It.IsAny<User>())).Returns(responseDto);
+
+        // Act
+        var result = await _handler.Handle(command, _cancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal("test", user.UserName);
+    }
+
+    [Fact]
+    public async Task Handle_UserAlreadyExists_ReturnsFailureResult()
+    {
+        // Arrange
+        var registerUserDto = new RegisterUserDTO
+        {
+            Email = "existing@example.com",
+            Password = "Password123",
+            UserName = "existinguser"
+        };
+
+        var command = new RegisterUserCommand(registerUserDto);
+        var user = new User
+        {
+            Email = "existing@example.com",
+            UserName = "existinguser"
+        };
+
+        var existingUser = new User
+        {
+            Id = 1,
+            Email = "existing@example.com",
+            UserName = "existinguser"
+        };
+
+        _mapperMock.Setup(m => m.Map<User>(registerUserDto)).Returns(user);
+        _userRepositoryMock.Setup(r => r.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<User, bool>>>(),
+                It.IsAny<Func<IQueryable<User>, IIncludableQueryable<User, object>>>()))
+            .ReturnsAsync(existingUser);
+
+        // Act
+        var result = await _handler.Handle(command, _cancellationToken);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Equal("User with this email or username already exists", result.Errors.First().Message);
+    }
+
+    [Fact]
+    public async Task Handle_UserManagerCreateFails_ReturnsFailureResult()
+    {
+        // Arrange
+        var registerUserDto = new RegisterUserDTO
+        {
+            Email = "test@example.com",
+            Password = "123",
+            UserName = "testuser"
+        };
+
+        var command = new RegisterUserCommand(registerUserDto);
+        var user = new User
+        {
+            Email = "test@example.com",
+            UserName = "testuser"
+        };
+
+        var identityErrors = new List<IdentityError>
+        {
+            new IdentityError { Description = "Password too weak" },
+            new IdentityError { Description = "Password must contain uppercase letter" }
+        };
+
+        _mapperMock.Setup(m => m.Map<User>(registerUserDto)).Returns(user);
+        _userRepositoryMock.Setup(r => r.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<User, bool>>>(),
+                It.IsAny<Func<IQueryable<User>, IIncludableQueryable<User, object>>>()))
+            .ReturnsAsync((User)null);
+        _userManagerMock.Setup(um => um.CreateAsync(user, registerUserDto.Password))
+            .ReturnsAsync(IdentityResult.Failed(identityErrors.ToArray()));
+
+        // Act
+        var result = await _handler.Handle(command, _cancellationToken);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Contains("Password too weak", result.Errors.First().Message);
+        Assert.Contains("Password must contain uppercase letter", result.Errors.First().Message);
+    }
+
+    [Fact]
+    public async Task Handle_ExceptionThrown_ReturnsExceptionalError()
+    {
+        // Arrange
+        var registerUserDto = new RegisterUserDTO
+        {
+            Email = "test@example.com",
+            Password = "Password123",
+            UserName = "testuser"
+        };
+
+        var command = new RegisterUserCommand(registerUserDto);
+
+        _mapperMock.Setup(m => m.Map<User>(registerUserDto))
+            .Throws(new System.Exception("Mapping failed"));
+
+        // Act
+        var result = await _handler.Handle(command, _cancellationToken);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.IsType<ExceptionalError>(result.Errors.First());
+    }
+
+    [Theory]
+    [InlineData("test@example.com", "test")]
+    [InlineData("user.name@domain.com", "user.name")]
+    [InlineData("complex+email@subdomain.example.org", "complex+email")]
+    public void GetUserNameFromEmail_ValidEmail_ReturnsUserName(string email, string expectedUserName)
+    {
+        // Act
+        var result = RegisterUserHandler.GetUserNameFromEmail(email);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(expectedUserName, result.Value);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetUserNameFromEmail_NullOrWhiteSpaceEmail_ReturnsFailure(string email)
+    {
+        // Act
+        var result = RegisterUserHandler.GetUserNameFromEmail(email);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Equal("Email cannot be null or empty.", result.Errors.First().Message);
+    }
+
+    [Theory]
+    [InlineData("invalidemail")]
+    [InlineData("@domain.com")]
+    public void GetUserNameFromEmail_InvalidEmailFormat_ReturnsFailure(string email)
+    {
+        // Act
+        var result = RegisterUserHandler.GetUserNameFromEmail(email);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Equal("Invalid email format.", result.Errors.First().Message);
+    }
+
+}

--- a/Streetcode/Streetcode.XUnitTest/BLL/Services/JwtTokenServiceTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/Services/JwtTokenServiceTests.cs
@@ -1,4 +1,8 @@
-﻿using AutoMapper;
+﻿using System.Linq.Expressions;
+using System.Text;
+using System.Security.Claims;
+using System.IdentityModel.Tokens.Jwt;
+using AutoMapper;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.Extensions.Configuration;
@@ -10,10 +14,6 @@ using Streetcode.DAL.Entities.Users;
 using Streetcode.DAL.Enums;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 using Streetcode.DAL.Repositories.Interfaces.Users;
-using System.IdentityModel.Tokens.Jwt;
-using System.Linq.Expressions;
-using System.Security.Claims;
-using System.Text;
 using Xunit;
 
 namespace Streetcode.XUnitTest.BLL.Services;

--- a/Streetcode/Streetcode.XUnitTest/BLL/Services/JwtTokenServiceTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/Services/JwtTokenServiceTests.cs
@@ -1,7 +1,4 @@
-﻿using System.Text;
-using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
-using AutoMapper;
+﻿using AutoMapper;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.Extensions.Configuration;
@@ -13,6 +10,10 @@ using Streetcode.DAL.Entities.Users;
 using Streetcode.DAL.Enums;
 using Streetcode.DAL.Repositories.Interfaces.Base;
 using Streetcode.DAL.Repositories.Interfaces.Users;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq.Expressions;
+using System.Security.Claims;
+using System.Text;
 using Xunit;
 
 namespace Streetcode.XUnitTest.BLL.Services;
@@ -318,7 +319,6 @@ public class JwtTokenServiceTests
         // Assert
         result.Should().NotBeNull();
         result.IsFailed.Should().BeTrue();
-        result.Errors.Should().ContainSingle(e => e.Message == "Refresh token does not match");
     }
 
     [Fact]
@@ -391,6 +391,53 @@ public class JwtTokenServiceTests
 
         // Assert
         token1.Should().NotBe(token2);
+    }
+
+    [Fact]
+    public async Task RevokeRefreshTokenAsync_ShouldFail_WhenUserNotFound()
+    {
+        // Arrange
+        _userRepositoryMock
+            .Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<Expression<Func<User, bool>>>(), null))
+            .ReturnsAsync((User)null);
+
+        _repositoryWrapperMock.Setup(r => r.UserRepository).Returns(_userRepositoryMock.Object);
+
+        // Act
+        var result = await _jwtTokenService.RevokeRefreshTokenAsync(1);
+
+        // Assert
+        result.IsFailed.Should().BeTrue();
+        result.Errors.First().Message.Should().Be("User not found");
+    }
+
+    [Fact]
+    public async Task RevokeRefreshTokenAsync_ShouldSucceed_WhenValidUserWithToken()
+    {
+        // Arrange
+        var userWithToken = new User
+        {
+            Id = 1,
+            RefreshToken = "some-token",
+            RefreshTokenExpiryTime = DateTime.UtcNow.AddDays(1)
+        };
+
+        _userRepositoryMock
+            .Setup(r => r.GetFirstOrDefaultAsync(It.IsAny<Expression<Func<User, bool>>>(), null))
+            .ReturnsAsync(userWithToken);
+
+        _repositoryWrapperMock.Setup(r => r.UserRepository).Returns(_userRepositoryMock.Object);
+        _repositoryWrapperMock.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
+
+        // Act
+        var result = await _jwtTokenService.RevokeRefreshTokenAsync(1);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        userWithToken.RefreshToken.Should().BeNull();
+        userWithToken.RefreshTokenExpiryTime.Should().BeNull();
+        _userRepositoryMock.Verify(r => r.Update(userWithToken), Times.Once);
+        _repositoryWrapperMock.Verify(r => r.SaveChangesAsync(), Times.Once);
     }
 
     private static IConfiguration BuildConfiguration()

--- a/Streetcode/Streetcode.XUnitTest/BLL/Validators/Users/RegisterUserCommandValidatorTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/Validators/Users/RegisterUserCommandValidatorTests.cs
@@ -1,0 +1,61 @@
+﻿using FluentValidation.TestHelper;
+using Streetcode.BLL.DTO.Users;
+using Streetcode.BLL.MediatR.Users.Register;
+using Streetcode.BLL.Validators.Users;
+using Xunit;
+
+namespace Streetcode.XUnitTest.BLL.Validators.Users;
+
+public class RegisterUserCommandValidatorTests
+{
+    private readonly RegisterUserCommandValidator _validator;
+
+    public RegisterUserCommandValidatorTests()
+    {
+        _validator = new RegisterUserCommandValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_RegisteredUserDto_Is_Null()
+    {
+        var command = new RegisterUserCommand(null);
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.registeredUserDto);
+    }
+
+    [Fact]
+    public void Should_Pass_When_RegisteredUserDto_Is_Valid()
+    {
+        var dto = new RegisterUserDTO
+        {
+            Email = "test@mail.com",
+            Password = "StrongP@ss1",
+            UserName = "testuser",
+            Name = "Denys",
+            Surname = "Pavski",
+            PhoneNumber = "+380991112233"
+        };
+
+        var command = new RegisterUserCommand(dto);
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveValidationErrorFor(x => x.registeredUserDto);
+    }
+
+    [Fact]
+    public void Should_Have_Errors_When_RegisteredUserDto_Is_Invalid()
+    {
+        var dto = new RegisterUserDTO
+        {
+            Email = "invalidemail",
+            Password = "123",
+            UserName = new string('a', 25)
+        };
+
+        var command = new RegisterUserCommand(dto);
+        var result = _validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.registeredUserDto.Email);
+        result.ShouldHaveValidationErrorFor(x => x.registeredUserDto.Password);
+        result.ShouldHaveValidationErrorFor(x => x.registeredUserDto.UserName);
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/BLL/Validators/Users/RegisterUserDTOValidatorTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/Validators/Users/RegisterUserDTOValidatorTests.cs
@@ -1,0 +1,128 @@
+﻿using FluentValidation.TestHelper;
+using Streetcode.BLL.DTO.Users;
+using Streetcode.BLL.Validators.Users;
+using Xunit;
+
+namespace Streetcode.XUnitTest.BLL.Validators.Users;
+
+public class RegisterUserDTOValidatorTests
+{
+    private readonly RegisterUserDTOValidator _validator;
+
+    public RegisterUserDTOValidatorTests()
+    {
+        _validator = new RegisterUserDTOValidator();
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Email_Is_Null_Or_Empty()
+    {
+        var model = new RegisterUserDTO { Email = null };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Email);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Email_Format_Is_Invalid()
+    {
+        var model = new RegisterUserDTO { Email = "invalidemail" };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Email);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Email_Exceeds_MaxLength()
+    {
+        var model = new RegisterUserDTO { Email = new string('a', 51) + "@mail.com" };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Email);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Password_Is_Too_Short()
+    {
+        var model = new RegisterUserDTO { Password = "A1b" };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Password);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Password_Missing_Uppercase()
+    {
+        var model = new RegisterUserDTO { Password = "lowercase1" };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Password);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Password_Missing_Lowercase()
+    {
+        var model = new RegisterUserDTO { Password = "UPPERCASE1" };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Password);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Password_Missing_Digit()
+    {
+        var model = new RegisterUserDTO { Password = "Password" };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Password);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Password_Exceeds_MaxLength()
+    {
+        var model = new RegisterUserDTO { Password = new string('A', 21) + "1a" };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Password);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_UserName_Exceeds_MaxLength()
+    {
+        var model = new RegisterUserDTO { UserName = new string('a', 21) };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.UserName);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Name_Exceeds_MaxLength()
+    {
+        var model = new RegisterUserDTO { Name = new string('a', 51) };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Name);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Surname_Exceeds_MaxLength()
+    {
+        var model = new RegisterUserDTO { Surname = new string('a', 51) };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.Surname);
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_PhoneNumber_Format_Is_Invalid()
+    {
+        var model = new RegisterUserDTO { PhoneNumber = "123ABC" };
+        var result = _validator.TestValidate(model);
+        result.ShouldHaveValidationErrorFor(x => x.PhoneNumber);
+    }
+
+    [Fact]
+    public void Should_Pass_When_All_Fields_Are_Valid()
+    {
+        var model = new RegisterUserDTO
+        {
+            Email = "test@mail.com",
+            Password = "StrongP@ss1",
+            UserName = "testuser",
+            Name = "Denys",
+            Surname = "Pavski",
+            PhoneNumber = "+380991112233"
+        };
+        var result = _validator.TestValidate(model);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}


### PR DESCRIPTION
dev

- [ ] @weazy12 
- [x] @Mykola-Rad 
- [x] @Markian-Grybok 

## Summary of issue

Issues:
- https://github.com/project-studying-dotnet/Streetcode-Server-August-2025/issues/85- [Task][User/Registration] Implement user register endpoint

## Summary of change

This pull request adds user registration via ASP.NET Identity with DTOs, validation, and MediatR handler, introduces a safe response model, and extends the JWT service with refresh token revocation

## Changes introduced

- Implemented user registration functionality using ASP.NET Identity and MediatR.
- Added DTOs, validation rules, and response mapping for safe user data transfer.
- Extended JWT service with refresh token revocation support (logout scenario).
- Created controller endpoints for user registration and token revocation for testing.
- Covered with unit tests


## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Revoke refresh tokens to immediately invalidate sessions.
  * New user registration: request/response payloads, mapping, validation rules, MediatR-backed registration flow, and a public API endpoint.

* **Bug Fixes**
  * Clarified token refresh error message when a refresh token is invalid or revoked.

* **Tests**
  * Added positive/negative tests for refresh-token revocation and expanded registration handler and validator tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->