### PR TITLE
Feature/178/ Implement Azure BLOB Storage

### DIFF
--- a/Streetcode/Streetcode.BLL/Factories/BlobStorage/BlobServiceFactory.cs
+++ b/Streetcode/Streetcode.BLL/Factories/BlobStorage/BlobServiceFactory.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Options;
+﻿using Azure.Storage.Blobs;
+using Microsoft.Extensions.Options;
 using Streetcode.BLL.Interfaces.BlobStorage;
 using Streetcode.BLL.Services.BlobStorageService;
 using Streetcode.DAL.Repositories.Interfaces.Base;
@@ -27,8 +28,18 @@ public class BlobServiceFactory : IBlobServiceFactory
 
         return storageType switch
         {
-            "azure" => new AzureBlobService(_azureBlobOptions),
+            "azure" => CreateAzureBlobService(),
             _ => new BlobService(_blobOptions, _repositoryWrapper),
         };
+    }
+
+    private IBlobService CreateAzureBlobService()
+    {
+        var options = _azureBlobOptions.Value;
+
+        var blobServiceClient = new BlobServiceClient(options.ConnectionString);
+        var blobContainerClient = blobServiceClient.GetBlobContainerClient(options.ContainerName);
+
+        return new AzureBlobService(blobContainerClient);
     }
 }

--- a/Streetcode/Streetcode.BLL/Factories/BlobStorage/BlobServiceFactory.cs
+++ b/Streetcode/Streetcode.BLL/Factories/BlobStorage/BlobServiceFactory.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.Extensions.Options;
+using Streetcode.BLL.Interfaces.BlobStorage;
+using Streetcode.BLL.Services.BlobStorageService;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+
+namespace Streetcode.BLL.Factories.BlobStorage;
+
+public class BlobServiceFactory : IBlobServiceFactory
+{
+    private readonly IOptions<BlobEnvironmentVariables> _blobOptions;
+    private readonly IOptions<AzureBlobEnvironmentVariables> _azureBlobOptions;
+    private readonly IRepositoryWrapper _repositoryWrapper;
+
+    public BlobServiceFactory(
+        IOptions<BlobEnvironmentVariables> blobOptions,
+        IOptions<AzureBlobEnvironmentVariables> azureBlobOptions,
+        IRepositoryWrapper repositoryWrapper)
+    {
+        _blobOptions = blobOptions;
+        _azureBlobOptions = azureBlobOptions;
+        _repositoryWrapper = repositoryWrapper;
+    }
+
+    public IBlobService CreateBlobService()
+    {
+        var storageType = _blobOptions.Value.StorageType?.ToLower() ?? "local";
+
+        return storageType switch
+        {
+            "azure" => new AzureBlobService(_azureBlobOptions),
+            _ => new BlobService(_blobOptions, _repositoryWrapper),
+        };
+    }
+}

--- a/Streetcode/Streetcode.BLL/Interfaces/BlobStorage/IBlobService.cs
+++ b/Streetcode/Streetcode.BLL/Interfaces/BlobStorage/IBlobService.cs
@@ -3,6 +3,7 @@
 public interface IBlobService
 {
     public string SaveFileInStorage(string base64, string name, string mimeType);
+    public void SaveFileInStorageWithName(string base64, string name, string extension);
     public MemoryStream FindFileInStorageAsMemoryStream(string name);
     public string UpdateFileInStorage(
         string previousBlobName,

--- a/Streetcode/Streetcode.BLL/Interfaces/BlobStorage/IBlobServiceFactory.cs
+++ b/Streetcode/Streetcode.BLL/Interfaces/BlobStorage/IBlobServiceFactory.cs
@@ -1,0 +1,6 @@
+﻿namespace Streetcode.BLL.Interfaces.BlobStorage;
+
+public interface IBlobServiceFactory
+{
+    IBlobService CreateBlobService();
+}

--- a/Streetcode/Streetcode.BLL/Services/BlobStorageService/AzureBlobEnvironmentVariables.cs
+++ b/Streetcode/Streetcode.BLL/Services/BlobStorageService/AzureBlobEnvironmentVariables.cs
@@ -1,0 +1,7 @@
+﻿namespace Streetcode.BLL.Services.BlobStorageService;
+
+public class AzureBlobEnvironmentVariables
+{
+    public string ConnectionString { get; set; }
+    public string ContainerName { get; set; }
+}

--- a/Streetcode/Streetcode.BLL/Services/BlobStorageService/AzureBlobService.cs
+++ b/Streetcode/Streetcode.BLL/Services/BlobStorageService/AzureBlobService.cs
@@ -1,0 +1,106 @@
+﻿using System.Security.Cryptography;
+using System.Text;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Microsoft.Extensions.Options;
+using Streetcode.BLL.Interfaces.BlobStorage;
+
+namespace Streetcode.BLL.Services.BlobStorageService;
+
+public class AzureBlobService : IBlobService
+{
+    private readonly BlobContainerClient _blobContainerClient;
+
+    public AzureBlobService(IOptions<AzureBlobEnvironmentVariables> azureOptions)
+    {
+        var options = azureOptions.Value;
+
+        var blobServiceClient = new BlobServiceClient(options.ConnectionString);
+        _blobContainerClient = blobServiceClient.GetBlobContainerClient(options.ContainerName);
+
+        _blobContainerClient.CreateIfNotExists();
+    }
+
+    public string SaveFileInStorage(string base64, string name, string mimeType)
+    {
+        var bytes = Convert.FromBase64String(base64);
+
+        var createdBlobName = $"{DateTime.Now}{name}"
+            .Replace(" ", "_")
+            .Replace(":", "-")
+            .Replace(".", "_");
+
+        var hashBlobName = HashFunction(createdBlobName);
+
+        using var stream = new MemoryStream(bytes);
+        var blobClient = _blobContainerClient.GetBlobClient($"{hashBlobName}.{mimeType}");
+
+        blobClient.Upload(stream, new BlobUploadOptions
+        {
+            HttpHeaders = new BlobHttpHeaders
+            {
+                ContentType = GetContentType(mimeType)
+            }
+        });
+
+        return $"{hashBlobName}.{mimeType}";
+    }
+
+    public MemoryStream FindFileInStorageAsMemoryStream(string name)
+    {
+        var bytes = FindFileInStorage(name);
+        return new MemoryStream(bytes);
+    }
+
+    public string FindFileInStorageAsBase64(string name)
+    {
+        var bytes = FindFileInStorage(name);
+        return Convert.ToBase64String(bytes);
+    }
+
+    public string UpdateFileInStorage(string previousBlobName, string base64Format, string newBlobName, string extension)
+    {
+        DeleteFileInStorage(previousBlobName);
+        return SaveFileInStorage(base64Format, newBlobName, extension);
+    }
+
+    public void DeleteFileInStorage(string name)
+    {
+        var blobClient = _blobContainerClient.GetBlobClient(name);
+        blobClient.DeleteIfExists();
+    }
+
+    private static string HashFunction(string createdFileName)
+    {
+        var enc = Encoding.UTF8;
+        var result = SHA256.HashData(enc.GetBytes(createdFileName));
+        return Convert.ToBase64String(result).Replace('/', '_');
+    }
+
+    private static string GetContentType(string mimeType)
+    {
+        return mimeType.ToLower() switch
+        {
+            "jpg" or "jpeg" => "image/jpeg",
+            "png" => "image/png",
+            "gif" => "image/gif",
+            "mp3" => "audio/mpeg",
+            "wav" => "audio/wav",
+            "pdf" => "application/pdf",
+            _ => "application/octet-stream"
+        };
+    }
+
+    private byte[] FindFileInStorage(string blobName)
+    {
+        var blobClient = _blobContainerClient.GetBlobClient(blobName);
+
+        if (!blobClient.Exists())
+        {
+            throw new FileNotFoundException($"Blob with name {blobName} not found.");
+        }
+
+        var downloadInfo = blobClient.DownloadContent();
+        return downloadInfo.Value.Content.ToArray();
+    }
+}

--- a/Streetcode/Streetcode.BLL/Services/BlobStorageService/AzureBlobService.cs
+++ b/Streetcode/Streetcode.BLL/Services/BlobStorageService/AzureBlobService.cs
@@ -41,6 +41,22 @@ public class AzureBlobService : IBlobService
         return $"{hashBlobName}.{mimeType}";
     }
 
+    public void SaveFileInStorageWithName(string base64, string name, string extension)
+    {
+        var bytes = Convert.FromBase64String(base64);
+
+        using var stream = new MemoryStream(bytes);
+        var blobClient = _blobContainerClient.GetBlobClient($"{name}.{extension}");
+
+        blobClient.Upload(stream, new BlobUploadOptions
+        {
+            HttpHeaders = new BlobHttpHeaders
+            {
+                ContentType = GetContentType(extension)
+            }
+        });
+    }
+
     public MemoryStream FindFileInStorageAsMemoryStream(string name)
     {
         var bytes = FindFileInStorage(name);

--- a/Streetcode/Streetcode.BLL/Services/BlobStorageService/AzureBlobService.cs
+++ b/Streetcode/Streetcode.BLL/Services/BlobStorageService/AzureBlobService.cs
@@ -11,14 +11,9 @@ public class AzureBlobService : IBlobService
 {
     private readonly BlobContainerClient _blobContainerClient;
 
-    public AzureBlobService(IOptions<AzureBlobEnvironmentVariables> azureOptions)
+    public AzureBlobService(BlobContainerClient blobContainerClient)
     {
-        var options = azureOptions.Value;
-
-        var blobServiceClient = new BlobServiceClient(options.ConnectionString);
-        _blobContainerClient = blobServiceClient.GetBlobContainerClient(options.ContainerName);
-
-        _blobContainerClient.CreateIfNotExists();
+        _blobContainerClient = blobContainerClient;
     }
 
     public string SaveFileInStorage(string base64, string name, string mimeType)
@@ -27,7 +22,7 @@ public class AzureBlobService : IBlobService
 
         var createdBlobName = $"{DateTime.Now}{name}"
             .Replace(" ", "_")
-            .Replace(":", "-")
+            .Replace(":", "_")
             .Replace(".", "_");
 
         var hashBlobName = HashFunction(createdBlobName);

--- a/Streetcode/Streetcode.BLL/Services/BlobStorageService/BlobEnvirovmentVariables.cs
+++ b/Streetcode/Streetcode.BLL/Services/BlobStorageService/BlobEnvirovmentVariables.cs
@@ -4,4 +4,5 @@ public class BlobEnvironmentVariables
 {
     public string BlobStoreKey { get; set; }
     public string BlobStorePath { get; set; }
+    public string StorageType { get; set; } = "Local";
 }

--- a/Streetcode/Streetcode.BLL/Services/BlobStorageService/BlobService.cs
+++ b/Streetcode/Streetcode.BLL/Services/BlobStorageService/BlobService.cs
@@ -57,7 +57,7 @@ public class BlobService : IBlobService
         return hashBlobStorageName;
     }
 
-    public void SaveFileInStorageBase64(string base64, string name, string extension)
+    public void SaveFileInStorageWithName(string base64, string name, string extension)
     {
         byte[] imageBytes = Convert.FromBase64String(base64);
         Directory.CreateDirectory(_blobPath);

--- a/Streetcode/Streetcode.BLL/Streetcode.BLL.csproj
+++ b/Streetcode/Streetcode.BLL/Streetcode.BLL.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Ardalis.Specification" Version="8.0.0" />
     <PackageReference Include="AutoMapper" Version="12.0.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.25.0" />
     <PackageReference Include="FluentResults" Version="3.15.1" />
     <PackageReference Include="FluentValidation" Version="12.0.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />

--- a/Streetcode/Streetcode.WebApi/Extensions/ConfigureHostBuilderExtensions.cs
+++ b/Streetcode/Streetcode.WebApi/Extensions/ConfigureHostBuilderExtensions.cs
@@ -4,6 +4,8 @@ using Streetcode.BLL.Services.BlobStorageService;
 using Streetcode.BLL.Services.Instagram;
 using Streetcode.BLL.Services.Payment;
 using Serilog.Sinks.SystemConsole.Themes;
+using Streetcode.BLL.Factories.BlobStorage;
+using Streetcode.BLL.Interfaces.BlobStorage;
 using Streetcode.BLL.Services.JwtService;
 
 namespace Streetcode.WebApi.Extensions;
@@ -23,6 +25,7 @@ public static class ConfigureHostBuilderExtensions
     public static void ConfigureBlob(this IServiceCollection services, WebApplicationBuilder builder)
     {
         services.Configure<BlobEnvironmentVariables>(builder.Configuration.GetSection("Blob"));
+        services.Configure<AzureBlobEnvironmentVariables>(builder.Configuration.GetSection("AzureBlob"));
     }
 
     public static void ConfigurePayment(this IServiceCollection services, WebApplicationBuilder builder)

--- a/Streetcode/Streetcode.WebApi/Extensions/SeedingLocalExtension.cs
+++ b/Streetcode/Streetcode.WebApi/Extensions/SeedingLocalExtension.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
+using Streetcode.BLL.Interfaces.BlobStorage;
 using Streetcode.BLL.Services.BlobStorageService;
 using Streetcode.DAL.Entities.AdditionalContent;
 using Streetcode.DAL.Entities.AdditionalContent.Coordinates.Types;
@@ -19,7 +20,6 @@ using Streetcode.DAL.Entities.Transactions;
 using Streetcode.DAL.Entities.Users;
 using Streetcode.DAL.Enums;
 using Streetcode.DAL.Persistence;
-using Streetcode.DAL.Repositories.Realizations.Base;
 
 namespace Streetcode.WebApi.Extensions
 {
@@ -39,14 +39,14 @@ namespace Streetcode.WebApi.Extensions
         {
             using (var scope = app.Services.CreateScope())
             {
-                Directory.CreateDirectory(app.Configuration.GetValue<string>("Blob:BlobStorePath"));
                 var dbContext = scope.ServiceProvider.GetRequiredService<StreetcodeDbContext>();
-                var blobOptions = app.Services.GetRequiredService<IOptions<BlobEnvironmentVariables>>();
-                string blobPath = app.Configuration.GetValue<string>("Blob:BlobStorePath");
-                var repo = new RepositoryWrapper(dbContext);
-                var blobService = new BlobService(blobOptions, repo);
+                var blobServiceFactory = scope.ServiceProvider.GetRequiredService<IBlobServiceFactory>();
+                var blobService = blobServiceFactory.CreateBlobService();
+                var blobOptions = scope.ServiceProvider.GetRequiredService<IOptions<BlobEnvironmentVariables>>();
+
                 string initialDataImagePath = "../Streetcode.DAL/InitialData/images.json";
                 string initialDataAudioPath = "../Streetcode.DAL/InitialData/audios.json";
+
                 if (!dbContext.Images.Any())
                 {
                     string imageJson = await File.ReadAllTextAsync(initialDataImagePath, Encoding.UTF8);
@@ -54,26 +54,13 @@ namespace Streetcode.WebApi.Extensions
                     var imgfromJson = JsonConvert.DeserializeObject<List<Image>>(imageJson);
                     var audiosfromJson = JsonConvert.DeserializeObject<List<Audio>>(audiosJson);
 
-                    foreach (var img in imgfromJson)
-                    {
-                        string filePath = Path.Combine(blobPath, img.BlobName);
-                        if (!File.Exists(filePath))
-                        {
-                            blobService.SaveFileInStorageBase64(img.Base64, img.BlobName.Split('.')[0], img.BlobName.Split('.')[1]);
-                        }
-                    }
+                    // Seed images
+                    await SeedMediaFiles(imgfromJson, blobService, blobOptions.Value);
 
-                    foreach (var audio in audiosfromJson)
-                    {
-                        string filePath = Path.Combine(blobPath, audio.BlobName);
-                        if (!File.Exists(filePath))
-                        {
-                            blobService.SaveFileInStorageBase64(audio.Base64, audio.BlobName.Split('.')[0], audio.BlobName.Split('.')[1]);
-                        }
-                    }
+                    // Seed audios
+                    await SeedMediaFiles(audiosfromJson, blobService, blobOptions.Value);
 
                     dbContext.Images.AddRange(imgfromJson);
-
                     await dbContext.SaveChangesAsync();
 
                     if (!dbContext.Responses.Any())
@@ -1293,7 +1280,7 @@ namespace Streetcode.WebApi.Extensions
                                         },
                                         new StreetcodeCategoryContent
                                         {
-                                            Text = "Хроніки про Т. Г. Шевченко",
+                                            Text = "Хроніки про Т. Г. Шевченка",
                                             SourceLinkCategoryId = 2,
                                             StreetcodeId = 2
                                         },
@@ -1465,6 +1452,73 @@ namespace Streetcode.WebApi.Extensions
                     await dbContext.SaveChangesAsync();
                 }
             }
+        }
+
+        private static async Task SeedMediaFiles<T>(List<T> mediaFiles, IBlobService blobService, BlobEnvironmentVariables blobConfig)
+            where T : class
+        {
+            foreach (var mediaFile in mediaFiles)
+            {
+                var blobNameProperty = typeof(T).GetProperty("BlobName");
+                var base64Property = typeof(T).GetProperty("Base64");
+
+                if (blobNameProperty?.GetValue(mediaFile) is string blobName &&
+                    base64Property?.GetValue(mediaFile) is string base64)
+                {
+                    await SeedMediaFile(blobService, blobConfig, blobName, base64);
+                }
+            }
+        }
+
+        private static Task SeedMediaFile(IBlobService blobService, BlobEnvironmentVariables blobConfig, string blobName, string base64)
+        {
+            // Check if we're using local storage and if file already exists
+            if (blobConfig.StorageType?.ToLower() != "azure")
+            {
+                string blobPath = blobConfig.BlobStorePath;
+                Directory.CreateDirectory(blobPath);
+                string filePath = Path.Combine(blobPath, blobName);
+                if (File.Exists(filePath))
+                {
+                    return Task.CompletedTask;
+                }
+            }
+
+            try
+            {
+                // For Azure storage, we need to check if blob exists differently
+                if (blobConfig.StorageType?.ToLower() == "azure")
+                {
+                    try
+                    {
+                        // Try to find the file - if it exists, this won't throw
+                        blobService.FindFileInStorageAsBase64(blobName);
+                        return Task.CompletedTask;
+                    }
+                    catch (FileNotFoundException)
+                    {
+                        // File doesn't exist, continue with seeding
+                    }
+                }
+
+                // Extract name and extension from blobName
+                var blobNameParts = blobName.Split('.');
+                if (blobNameParts.Length >= 2)
+                {
+                    var nameWithoutExtension = string.Join(".", blobNameParts.Take(blobNameParts.Length - 1));
+                    var extension = blobNameParts.Last();
+
+                    // Use the common interface method
+                    blobService.SaveFileInStorageWithName(base64, nameWithoutExtension, extension);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Log error but continue with other files
+                Console.WriteLine($"Error seeding file {blobName}: {ex.Message}");
+            }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/Streetcode/Streetcode.WebApi/Extensions/ServiceCollectionExtensions.cs
+++ b/Streetcode/Streetcode.WebApi/Extensions/ServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ using Streetcode.BLL.Interfaces.Text;
 using Streetcode.BLL.Services.Text;
 using Streetcode.BLL.MediatR;
 using Streetcode.BLL;
+using Streetcode.BLL.Factories.BlobStorage;
 using Streetcode.BLL.Interfaces.Jwt;
 using Streetcode.BLL.Services.JwtService;
 using Streetcode.DAL.Entities.Users;
@@ -57,7 +58,14 @@ public static class ServiceCollectionExtensions
             ApplicationAssembly.Assembly,
             includeInternalTypes: true);
 
-        services.AddScoped<IBlobService, BlobService>();
+        services.AddScoped<IBlobServiceFactory, BlobServiceFactory>();
+
+        services.AddScoped<IBlobService>(provider =>
+        {
+            var factory = provider.GetRequiredService<IBlobServiceFactory>();
+            return factory.CreateBlobService();
+        });
+
         services.AddScoped<ILoggerService, LoggerService>();
         services.AddScoped<IEmailService, EmailService>();
         services.AddScoped<IPaymentService, PaymentService>();

--- a/Streetcode/Streetcode.XUnitTest/BLL/Factories/BlobServiceFactoryTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/Factories/BlobServiceFactoryTests.cs
@@ -1,0 +1,166 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Streetcode.BLL.Factories.BlobStorage;
+using Streetcode.BLL.Services.BlobStorageService;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using Xunit;
+
+namespace Streetcode.XUnitTest.BLL.Factories;
+
+public class BlobServiceFactoryTests
+{
+    private readonly Mock<IOptions<BlobEnvironmentVariables>> _mockBlobOptions;
+    private readonly Mock<IOptions<AzureBlobEnvironmentVariables>> _mockAzureBlobOptions;
+    private readonly Mock<IRepositoryWrapper> _mockRepositoryWrapper;
+
+    public BlobServiceFactoryTests()
+    {
+        _mockBlobOptions = new Mock<IOptions<BlobEnvironmentVariables>>();
+        _mockAzureBlobOptions = new Mock<IOptions<AzureBlobEnvironmentVariables>>();
+        _mockRepositoryWrapper = new Mock<IRepositoryWrapper>();
+    }
+
+    [Fact]
+    public void CreateBlobService_WithValidAzureConfig_ReturnsAzureBlobService()
+    {
+        // Arrange
+        var blobConfig = new BlobEnvironmentVariables
+        {
+            BlobStorePath = "../../BlobStorageFolder/",
+            BlobStoreKey = "test-key",
+            StorageType = "Azure"
+        };
+
+        var azureConfig = new AzureBlobEnvironmentVariables
+        {
+            ConnectionString = "DefaultEndpointsProtocol=https;AccountName=test;AccountKey=dGVzdA==;EndpointSuffix=core.windows.net",
+            ContainerName = "test-container"
+        };
+
+        _mockBlobOptions.Setup(x => x.Value).Returns(blobConfig);
+        _mockAzureBlobOptions.Setup(x => x.Value).Returns(azureConfig);
+
+        var factory = new BlobServiceFactory(_mockBlobOptions.Object, _mockAzureBlobOptions.Object, _mockRepositoryWrapper.Object);
+
+        // Act
+        var result = factory.CreateBlobService();
+
+        // Assert
+        result.Should().BeOfType<AzureBlobService>();
+    }
+
+    [Fact]
+    public void CreateBlobService_WithEmptyConnectionString_ReturnsLocalBlobService()
+    {
+        // Arrange
+        var blobConfig = new BlobEnvironmentVariables
+        {
+            BlobStorePath = "../../BlobStorageFolder/",
+            BlobStoreKey = "test-key",
+        };
+
+        var azureConfig = new AzureBlobEnvironmentVariables
+        {
+            ConnectionString = "", // порожня
+            ContainerName = "test-container"
+        };
+
+        _mockBlobOptions.Setup(x => x.Value).Returns(blobConfig);
+        _mockAzureBlobOptions.Setup(x => x.Value).Returns(azureConfig);
+
+        var factory = new BlobServiceFactory(_mockBlobOptions.Object, _mockAzureBlobOptions.Object, _mockRepositoryWrapper.Object);
+
+        // Act
+        var result = factory.CreateBlobService();
+
+        // Assert
+        result.Should().BeOfType<BlobService>();
+    }
+
+    [Fact]
+    public void CreateBlobService_WithEmptyContainerName_ReturnsLocalBlobService()
+    {
+        // Arrange
+        var blobConfig = new BlobEnvironmentVariables
+        {
+            BlobStorePath = "../../BlobStorageFolder/",
+            BlobStoreKey = "test-key"
+        };
+
+        var azureConfig = new AzureBlobEnvironmentVariables
+        {
+            ConnectionString = "DefaultEndpointsProtocol=https;AccountName=test;AccountKey=dGVzdA==;EndpointSuffix=core.windows.net",
+            ContainerName = "" // порожня
+        };
+
+        _mockBlobOptions.Setup(x => x.Value).Returns(blobConfig);
+        _mockAzureBlobOptions.Setup(x => x.Value).Returns(azureConfig);
+
+        var factory = new BlobServiceFactory(_mockBlobOptions.Object, _mockAzureBlobOptions.Object, _mockRepositoryWrapper.Object);
+
+        // Act
+        var result = factory.CreateBlobService();
+
+        // Assert
+        result.Should().BeOfType<BlobService>();
+    }
+
+    [Fact]
+    public void CreateBlobService_WithNullAzureConfig_ReturnsLocalBlobService()
+    {
+        // Arrange
+        var blobConfig = new BlobEnvironmentVariables
+        {
+            BlobStorePath = "../../BlobStorageFolder/",
+            BlobStoreKey = "test-key"
+        };
+
+        _mockBlobOptions.Setup(x => x.Value).Returns(blobConfig);
+        _mockAzureBlobOptions.Setup(x => x.Value).Returns((AzureBlobEnvironmentVariables)null);
+
+        var factory = new BlobServiceFactory(_mockBlobOptions.Object, _mockAzureBlobOptions.Object, _mockRepositoryWrapper.Object);
+
+        // Act
+        var result = factory.CreateBlobService();
+
+        // Assert
+        result.Should().BeOfType<BlobService>();
+    }
+
+    [Theory]
+    [InlineData(null, "container")]
+    [InlineData("", "container")]
+    [InlineData("  ", "container")]
+    [InlineData("connection-string", null)]
+    [InlineData("connection-string", "")]
+    [InlineData("connection-string", "  ")]
+    [InlineData(null, null)]
+    [InlineData("", "")]
+    public void CreateBlobService_WithInvalidAzureConfig_ReturnsLocalBlobService(string connectionString, string containerName)
+    {
+        // Arrange
+        var blobConfig = new BlobEnvironmentVariables
+        {
+            BlobStorePath = "../../BlobStorageFolder/",
+            BlobStoreKey = "test-key"
+        };
+
+        var azureConfig = new AzureBlobEnvironmentVariables
+        {
+            ConnectionString = connectionString,
+            ContainerName = containerName
+        };
+
+        _mockBlobOptions.Setup(x => x.Value).Returns(blobConfig);
+        _mockAzureBlobOptions.Setup(x => x.Value).Returns(azureConfig);
+
+        var factory = new BlobServiceFactory(_mockBlobOptions.Object, _mockAzureBlobOptions.Object, _mockRepositoryWrapper.Object);
+
+        // Act
+        var result = factory.CreateBlobService();
+
+        // Assert
+        result.Should().BeOfType<BlobService>();
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/BLL/Services/AzureBlobServiceTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/Services/AzureBlobServiceTests.cs
@@ -380,4 +380,152 @@ public class AzureBlobServiceTests
         result.Should().EndWith($".{mimeType}");
         capturedStream.Should().NotBeNull();
     }
+
+    [Fact]
+    public void SaveFileInStorageWithName_ValidParameters_ShouldUploadWithCorrectNameAndExtension()
+    {
+        // Arrange
+        var testData = "Hello World";
+        var base64Data = Convert.ToBase64String(Encoding.UTF8.GetBytes(testData));
+        var fileName = "custom-name";
+        var extension = "png";
+
+        var mockResponse = new Mock<Response<BlobContentInfo>>();
+        var blobContentInfo = BlobsModelFactory.BlobContentInfo(
+            eTag: new ETag("etag"),
+            lastModified: DateTimeOffset.UtcNow,
+            contentHash: Array.Empty<byte>(),
+            versionId: "version",
+            encryptionKeySha256: "key",
+            encryptionScope: "scope",
+            blobSequenceNumber: 1);
+        mockResponse.Setup(x => x.Value).Returns(blobContentInfo);
+
+        string capturedBlobName = null!;
+        _mockContainerClient
+            .Setup(x => x.GetBlobClient(It.IsAny<string>()))
+            .Callback<string>(name => capturedBlobName = name)
+            .Returns(_mockBlobClient.Object);
+
+        BlobUploadOptions capturedOptions = null!;
+        _mockBlobClient
+            .Setup(x => x.Upload(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<Stream, BlobUploadOptions, CancellationToken>((_, options, _) => capturedOptions = options)
+            .Returns(mockResponse.Object);
+
+        // Act
+        _azureBlobService.SaveFileInStorageWithName(base64Data, fileName, extension);
+
+        // Assert
+        capturedBlobName.Should().Be($"{fileName}.{extension}");
+        capturedOptions.Should().NotBeNull();
+        capturedOptions.HttpHeaders.ContentType.Should().Be("image/png");
+    }
+
+    [Theory]
+    [InlineData("jpg", "image/jpeg")]
+    [InlineData("jpeg", "image/jpeg")]
+    [InlineData("png", "image/png")]
+    [InlineData("gif", "image/gif")]
+    [InlineData("mp3", "audio/mpeg")]
+    [InlineData("wav", "audio/wav")]
+    [InlineData("pdf", "application/pdf")]
+    [InlineData("unknown", "application/octet-stream")]
+    public void SaveFileInStorageWithName_DifferentExtensions_ShouldSetCorrectContentType(string extension, string expectedContentType)
+    {
+        // Arrange
+        var testData = "Hello World";
+        var base64Data = Convert.ToBase64String(Encoding.UTF8.GetBytes(testData));
+        var fileName = "custom-name";
+
+        var mockResponse = new Mock<Response<BlobContentInfo>>();
+        var blobContentInfo = BlobsModelFactory.BlobContentInfo(
+            eTag: new ETag("etag"),
+            lastModified: DateTimeOffset.UtcNow,
+            contentHash: Array.Empty<byte>(),
+            versionId: "version",
+            encryptionKeySha256: "key",
+            encryptionScope: "scope",
+            blobSequenceNumber: 1);
+        mockResponse.Setup(x => x.Value).Returns(blobContentInfo);
+
+        BlobUploadOptions capturedOptions = null!;
+        _mockBlobClient
+            .Setup(x => x.Upload(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<Stream, BlobUploadOptions, CancellationToken>((_, options, _) => capturedOptions = options)
+            .Returns(mockResponse.Object);
+
+        // Act
+        _azureBlobService.SaveFileInStorageWithName(base64Data, fileName, extension);
+
+        // Assert
+        capturedOptions.Should().NotBeNull();
+        capturedOptions.HttpHeaders.ContentType.Should().Be(expectedContentType);
+    }
+
+    [Fact]
+    public void SaveFileInStorageWithName_InvalidBase64_ShouldThrowFormatException()
+    {
+        // Arrange
+        var base64Data = "invalid-base64-string";
+        var fileName = "custom-name";
+        var extension = "jpg";
+
+        // Act & Assert
+        var action = () => _azureBlobService.SaveFileInStorageWithName(base64Data, fileName, extension);
+        action.Should().Throw<FormatException>();
+    }
+
+    [Fact]
+    public void SaveFileInStorageWithName_NullBase64_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        string base64Data = null!;
+        var fileName = "custom-name";
+        var extension = "jpg";
+
+        // Act & Assert
+        var action = () => _azureBlobService.SaveFileInStorageWithName(base64Data, fileName, extension);
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Theory]
+    [InlineData("file with spaces.txt")]
+    [InlineData("file:with:colons.jpg")]
+    [InlineData("file.with.dots.png")]
+    [InlineData("normal-file.pdf")]
+    public void SaveFileInStorageWithName_FileNameWithSpecialCharacters_ShouldPreserveNameAndExtension(string fileName)
+    {
+        // Arrange
+        var testData = "Hello World";
+        var base64Data = Convert.ToBase64String(Encoding.UTF8.GetBytes(testData));
+        var extension = "jpg";
+
+        var mockResponse = new Mock<Response<BlobContentInfo>>();
+        var blobContentInfo = BlobsModelFactory.BlobContentInfo(
+            eTag: new ETag("etag"),
+            lastModified: DateTimeOffset.UtcNow,
+            contentHash: Array.Empty<byte>(),
+            versionId: "version",
+            encryptionKeySha256: "key",
+            encryptionScope: "scope",
+            blobSequenceNumber: 1);
+        mockResponse.Setup(x => x.Value).Returns(blobContentInfo);
+
+        string capturedBlobName = null!;
+        _mockContainerClient
+            .Setup(x => x.GetBlobClient(It.IsAny<string>()))
+            .Callback<string>(name => capturedBlobName = name)
+            .Returns(_mockBlobClient.Object);
+
+        _mockBlobClient
+            .Setup(x => x.Upload(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .Returns(mockResponse.Object);
+
+        // Act
+        _azureBlobService.SaveFileInStorageWithName(base64Data, fileName, extension);
+
+        // Assert
+        capturedBlobName.Should().Be($"{fileName}.{extension}");
+    }
 }

--- a/Streetcode/Streetcode.XUnitTest/BLL/Services/AzureBlobServiceTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/Services/AzureBlobServiceTests.cs
@@ -1,0 +1,383 @@
+﻿using System.Text;
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using FluentAssertions;
+using Moq;
+using Streetcode.BLL.Services.BlobStorageService;
+using Xunit;
+
+namespace Streetcode.XUnitTest.BLL.Services;
+
+public class AzureBlobServiceTests
+{
+    private readonly Mock<BlobContainerClient> _mockContainerClient;
+    private readonly Mock<BlobClient> _mockBlobClient;
+    private readonly AzureBlobService _azureBlobService;
+
+    public AzureBlobServiceTests()
+    {
+        _mockContainerClient = new Mock<BlobContainerClient>();
+        _mockBlobClient = new Mock<BlobClient>();
+
+        _mockContainerClient
+            .Setup(x => x.GetBlobClient(It.IsAny<string>()))
+            .Returns(_mockBlobClient.Object);
+
+        _azureBlobService = new AzureBlobService(_mockContainerClient.Object);
+    }
+
+    [Fact]
+    public void SaveFileInStorage_ValidBase64AndParameters_ShouldReturnHashedBlobName()
+    {
+        // Arrange
+        var testData = "Hello World";
+        var base64Data = Convert.ToBase64String(Encoding.UTF8.GetBytes(testData));
+        var fileName = "test-file";
+        var mimeType = "jpg";
+
+        var mockResponse = new Mock<Response<BlobContentInfo>>();
+        var blobContentInfo = BlobsModelFactory.BlobContentInfo(
+            eTag: new ETag("etag"),
+            lastModified: DateTimeOffset.UtcNow,
+            contentHash: Array.Empty<byte>(),
+            versionId: "version",
+            encryptionKeySha256: "key",
+            encryptionScope: "scope",
+            blobSequenceNumber: 1);
+        mockResponse.Setup(x => x.Value).Returns(blobContentInfo);
+
+        _mockBlobClient
+            .Setup(x => x.Upload(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .Returns(mockResponse.Object);
+
+        // Act
+        var result = _azureBlobService.SaveFileInStorage(base64Data, fileName, mimeType);
+
+        // Assert
+        result.Should().NotBeNullOrEmpty();
+        result.Should().EndWith($".{mimeType}");
+
+        _mockContainerClient.Verify(x => x.GetBlobClient(It.IsAny<string>()), Times.Once);
+        _mockBlobClient.Verify(x => x.Upload(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Theory]
+    [InlineData("jpg", "image/jpeg")]
+    [InlineData("jpeg", "image/jpeg")]
+    [InlineData("png", "image/png")]
+    [InlineData("gif", "image/gif")]
+    [InlineData("mp3", "audio/mpeg")]
+    [InlineData("wav", "audio/wav")]
+    [InlineData("pdf", "application/pdf")]
+    [InlineData("unknown", "application/octet-stream")]
+    public void SaveFileInStorage_DifferentMimeTypes_ShouldSetCorrectContentType(string mimeType, string expectedContentType)
+    {
+        // Arrange
+        var testData = "Hello World";
+        var base64Data = Convert.ToBase64String(Encoding.UTF8.GetBytes(testData));
+        var fileName = "test-file";
+
+        var mockResponse = new Mock<Response<BlobContentInfo>>();
+        var blobContentInfo = BlobsModelFactory.BlobContentInfo(
+            eTag: new ETag("etag"),
+            lastModified: DateTimeOffset.UtcNow,
+            contentHash: Array.Empty<byte>(),
+            versionId: "version",
+            encryptionKeySha256: "key",
+            encryptionScope: "scope",
+            blobSequenceNumber: 1);
+        mockResponse.Setup(x => x.Value).Returns(blobContentInfo);
+
+        BlobUploadOptions capturedOptions = null!;
+        _mockBlobClient
+            .Setup(x => x.Upload(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<Stream, BlobUploadOptions, CancellationToken>((_, options, _) => capturedOptions = options)
+            .Returns(mockResponse.Object);
+
+        // Act
+        _azureBlobService.SaveFileInStorage(base64Data, fileName, mimeType);
+
+        // Assert
+        capturedOptions.Should().NotBeNull();
+        capturedOptions.HttpHeaders.ContentType.Should().Be(expectedContentType);
+    }
+
+    [Fact]
+    public void FindFileInStorageAsMemoryStream_ExistingFile_ShouldReturnMemoryStream()
+    {
+        // Arrange
+        var blobName = "test-blob.jpg";
+        var testData = Encoding.UTF8.GetBytes("Test file content");
+        var binaryData = BinaryData.FromBytes(testData);
+
+        var mockResponse = new Mock<Response<BlobDownloadResult>>();
+        var downloadResult = BlobsModelFactory.BlobDownloadResult(content: binaryData);
+        mockResponse.Setup(x => x.Value).Returns(downloadResult);
+
+        _mockBlobClient.Setup(x => x.Exists(It.IsAny<CancellationToken>())).Returns(Response.FromValue(true, Mock.Of<Response>()));
+        _mockBlobClient.Setup(x => x.DownloadContent()).Returns(mockResponse.Object);
+
+        // Act
+        var result = _azureBlobService.FindFileInStorageAsMemoryStream(blobName);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.ToArray().Should().BeEquivalentTo(testData);
+
+        _mockContainerClient.Verify(x => x.GetBlobClient(blobName), Times.Once);
+        _mockBlobClient.Verify(x => x.Exists(It.IsAny<CancellationToken>()), Times.Once);
+        _mockBlobClient.Verify(x => x.DownloadContent(), Times.Once);
+    }
+
+    [Fact]
+    public void FindFileInStorageAsMemoryStream_NonExistingFile_ShouldThrowFileNotFoundException()
+    {
+        // Arrange
+        var blobName = "non-existing-blob.jpg";
+
+        _mockBlobClient.Setup(x => x.Exists(It.IsAny<CancellationToken>())).Returns(Response.FromValue(false, Mock.Of<Response>()));
+
+        // Act & Assert
+        var action = () => _azureBlobService.FindFileInStorageAsMemoryStream(blobName);
+
+        action.Should().Throw<FileNotFoundException>()
+            .WithMessage($"Blob with name {blobName} not found.");
+
+        _mockBlobClient.Verify(x => x.DownloadContent(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public void FindFileInStorageAsBase64_ExistingFile_ShouldReturnBase64String()
+    {
+        // Arrange
+        const string blobName = "test-blob.jpg";
+        var testData = "Test file content"u8.ToArray();
+        var expectedBase64 = Convert.ToBase64String(testData);
+        var binaryData = BinaryData.FromBytes(testData);
+
+        var mockResponse = new Mock<Response<BlobDownloadResult>>();
+        var downloadResult = BlobsModelFactory.BlobDownloadResult(content: binaryData);
+        mockResponse.Setup(x => x.Value).Returns(downloadResult);
+
+        _mockBlobClient.Setup(x => x.Exists(It.IsAny<CancellationToken>())).Returns(Response.FromValue(true, Mock.Of<Response>()));
+        _mockBlobClient.Setup(x => x.DownloadContent()).Returns(mockResponse.Object);
+
+        // Act
+        var result = _azureBlobService.FindFileInStorageAsBase64(blobName);
+
+        // Assert
+        result.Should().Be(expectedBase64);
+
+        _mockContainerClient.Verify(x => x.GetBlobClient(blobName), Times.Once);
+        _mockBlobClient.Verify(x => x.Exists(It.IsAny<CancellationToken>()), Times.Once);
+        _mockBlobClient.Verify(x => x.DownloadContent(), Times.Once);
+    }
+
+    [Fact]
+    public void FindFileInStorageAsBase64_NonExistingFile_ShouldThrowFileNotFoundException()
+    {
+        // Arrange
+        var blobName = "non-existing-blob.jpg";
+
+        _mockBlobClient.Setup(x => x.Exists(It.IsAny<CancellationToken>())).Returns(Response.FromValue(false, Mock.Of<Response>()));
+
+        // Act & Assert
+        var action = () => _azureBlobService.FindFileInStorageAsBase64(blobName);
+
+        action.Should().Throw<FileNotFoundException>()
+            .WithMessage($"Blob with name {blobName} not found.");
+    }
+
+    [Fact]
+    public void UpdateFileInStorage_ValidParameters_ShouldDeleteOldAndSaveNewFile()
+    {
+        // Arrange
+        var previousBlobName = "old-blob.jpg";
+        var newBlobName = "new-file";
+        var base64Data = Convert.ToBase64String(Encoding.UTF8.GetBytes("New content"));
+        var extension = "png";
+
+        var mockDeleteResponse = new Mock<Response<bool>>();
+        mockDeleteResponse.Setup(x => x.Value).Returns(true);
+
+        var mockUploadResponse = new Mock<Response<BlobContentInfo>>();
+        var blobContentInfo = BlobsModelFactory.BlobContentInfo(
+            eTag: new ETag("etag"),
+            lastModified: DateTimeOffset.UtcNow,
+            contentHash: Array.Empty<byte>(),
+            versionId: "version",
+            encryptionKeySha256: "key",
+            encryptionScope: "scope",
+            blobSequenceNumber: 1);
+        mockUploadResponse.Setup(x => x.Value).Returns(blobContentInfo);
+
+        _mockBlobClient.Setup(x => x.DeleteIfExists(It.IsAny<DeleteSnapshotsOption>(), It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()))
+            .Returns(mockDeleteResponse.Object);
+        _mockBlobClient.Setup(x => x.Upload(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .Returns(mockUploadResponse.Object);
+
+        // Act
+        var result = _azureBlobService.UpdateFileInStorage(previousBlobName, base64Data, newBlobName, extension);
+
+        // Assert
+        result.Should().NotBeNullOrEmpty();
+        result.Should().EndWith($".{extension}");
+
+        // Verify delete was called for the previous blob
+        _mockContainerClient.Verify(x => x.GetBlobClient(previousBlobName), Times.Once);
+        _mockBlobClient.Verify(x => x.DeleteIfExists(It.IsAny<DeleteSnapshotsOption>(), It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()), Times.Once);
+
+        // Verify upload was called for the new blob
+        _mockBlobClient.Verify(x => x.Upload(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public void DeleteFileInStorage_ExistingFile_ShouldCallDeleteIfExists()
+    {
+        // Arrange
+        var blobName = "test-blob.jpg";
+
+        var mockResponse = new Mock<Response<bool>>();
+        mockResponse.Setup(x => x.Value).Returns(true);
+
+        _mockBlobClient.Setup(x => x.DeleteIfExists(It.IsAny<DeleteSnapshotsOption>(), It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()))
+            .Returns(mockResponse.Object);
+
+        // Act
+        _azureBlobService.DeleteFileInStorage(blobName);
+
+        // Assert
+        _mockContainerClient.Verify(x => x.GetBlobClient(blobName), Times.Once);
+        _mockBlobClient.Verify(x => x.DeleteIfExists(It.IsAny<DeleteSnapshotsOption>(), It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public void DeleteFileInStorage_NonExistingFile_ShouldNotThrow()
+    {
+        // Arrange
+        var blobName = "non-existing-blob.jpg";
+
+        var mockResponse = new Mock<Response<bool>>();
+        mockResponse.Setup(x => x.Value).Returns(false);
+
+        _mockBlobClient.Setup(x => x.DeleteIfExists(It.IsAny<DeleteSnapshotsOption>(), It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()))
+            .Returns(mockResponse.Object);
+
+        // Act & Assert
+        var action = () => _azureBlobService.DeleteFileInStorage(blobName);
+        action.Should().NotThrow();
+
+        _mockContainerClient.Verify(x => x.GetBlobClient(blobName), Times.Once);
+        _mockBlobClient.Verify(x => x.DeleteIfExists(It.IsAny<DeleteSnapshotsOption>(), It.IsAny<BlobRequestConditions>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Theory]
+    [InlineData("test file.txt")]
+    [InlineData("file:with:colons.jpg")]
+    [InlineData("file.with.dots.png")]
+    [InlineData("normal-file.pdf")]
+    public void SaveFileInStorage_FileNameWithSpecialCharacters_ShouldReplaceSpecialCharacters(string fileName)
+    {
+        // Arrange
+        var testData = "Hello World";
+        var base64Data = Convert.ToBase64String(Encoding.UTF8.GetBytes(testData));
+        var mimeType = "jpg";
+
+        var mockResponse = new Mock<Response<BlobContentInfo>>();
+        var blobContentInfo = BlobsModelFactory.BlobContentInfo(
+            eTag: new ETag("etag"),
+            lastModified: DateTimeOffset.UtcNow,
+            contentHash: Array.Empty<byte>(),
+            versionId: "version",
+            encryptionKeySha256: "key",
+            encryptionScope: "scope",
+            blobSequenceNumber: 1);
+        mockResponse.Setup(x => x.Value).Returns(blobContentInfo);
+
+        string capturedBlobName = null!;
+        _mockContainerClient
+            .Setup(x => x.GetBlobClient(It.IsAny<string>()))
+            .Callback<string>(name => capturedBlobName = name)
+            .Returns(_mockBlobClient.Object);
+
+        _mockBlobClient
+            .Setup(x => x.Upload(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .Returns(mockResponse.Object);
+
+        // Act
+        var result = _azureBlobService.SaveFileInStorage(base64Data, fileName, mimeType);
+
+        // Assert
+        result.Should().NotBeNullOrEmpty();
+        result.Should().EndWith($".{mimeType}");
+
+        // The blob name should be hashed, but we can verify special characters were replaced
+        capturedBlobName.Should().NotContain(" ");
+        capturedBlobName.Should().NotContain(":");
+        capturedBlobName[.. (capturedBlobName.Length - mimeType.Length - 1)] // Exclude extension
+            .Should().NotContain(".");
+    }
+
+    [Fact]
+    public void SaveFileInStorage_InvalidBase64_ShouldThrowFormatException()
+    {
+        // Arrange
+        var base64Data = "invalid-base64-string";
+        var fileName = "test-file";
+        var mimeType = "jpg";
+
+        // Act & Assert
+        var action = () => _azureBlobService.SaveFileInStorage(base64Data, fileName, mimeType);
+        action.Should().Throw<FormatException>();
+    }
+
+    [Fact]
+    public void SaveFileInStorage_NullBase64_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        string base64Data = null!;
+        var fileName = "test-file";
+        var mimeType = "jpg";
+
+        // Act & Assert
+        var action = () => _azureBlobService.SaveFileInStorage(base64Data, fileName, mimeType);
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void SaveFileInStorage_LargeBinaryData_ShouldUploadSuccessfully()
+    {
+        // Arrange
+        var largeData = new byte[1024 * 1024]; // 1MB of data
+        Random.Shared.NextBytes(largeData);
+        var base64Data = Convert.ToBase64String(largeData);
+        var fileName = "large-file";
+        var mimeType = "bin";
+
+        var mockResponse = new Mock<Response<BlobContentInfo>>();
+        var blobContentInfo = BlobsModelFactory.BlobContentInfo(
+            eTag: new ETag("etag"),
+            lastModified: DateTimeOffset.UtcNow,
+            contentHash: Array.Empty<byte>(),
+            versionId: "version",
+            encryptionKeySha256: "key",
+            encryptionScope: "scope",
+            blobSequenceNumber: 1);
+        mockResponse.Setup(x => x.Value).Returns(blobContentInfo);
+
+        Stream capturedStream = null!;
+        _mockBlobClient
+            .Setup(x => x.Upload(It.IsAny<Stream>(), It.IsAny<BlobUploadOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<Stream, BlobUploadOptions, CancellationToken>((stream, _, _) => capturedStream = stream)
+            .Returns(mockResponse.Object);
+
+        // Act
+        var result = _azureBlobService.SaveFileInStorage(base64Data, fileName, mimeType);
+
+        // Assert
+        result.Should().NotBeNullOrEmpty();
+        result.Should().EndWith($".{mimeType}");
+        capturedStream.Should().NotBeNull();
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/Streetcode.XUnitTest.csproj
+++ b/Streetcode/Streetcode.XUnitTest/Streetcode.XUnitTest.csproj
@@ -52,7 +52,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <Folder Include="BLL\Services\" />
 	  <Folder Include="BLL\Validators\Other\" />
 	  <Folder Include="WebApi\Middlewares\" />
 	  <Folder Include="WebApi\Extensions\" />


### PR DESCRIPTION
dev

## Code reviewers

- [ ] @weazy12 
- [ ] @Markian-Grybok 
- [ ] @denys-pavskyi 

## Summary of issue

- https://github.com/project-studying-dotnet/Streetcode-Server-August-2025/issues/176 
- https://github.com/project-studying-dotnet/Streetcode-Server-August-2025/issues/178

## Summary of change

This pull request introduces support for Azure Blob Storage as an alternative to local file storage, enabling the application to flexibly choose between storage backends based on configuration. The changes include the implementation of a factory pattern for blob services, the addition of Azure-specific blob service classes and configuration, and refactoring of the seeding logic to work seamlessly with both storage types.
Closes #176, #178

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions