### PR TITLE
Added Delete endpoint for FavouriteStreeetcode. Issue #231

### DIFF
--- a/Streetcode/Streetcode.BLL/DTO/FavouriteStreetcode/FavouriteStreetcodeDTO.cs
+++ b/Streetcode/Streetcode.BLL/DTO/FavouriteStreetcode/FavouriteStreetcodeDTO.cs
@@ -1,0 +1,15 @@
+﻿using Streetcode.DAL.Entities.Streetcode;
+using Streetcode.DAL.Entities.Users;
+
+namespace Streetcode.BLL.DTO.FavouriteStreetcode;
+
+public class FavouriteStreetcodeDTO
+{
+    public int Id { get; set; }
+
+    public int UserId { get; set; }
+    public int StreetcodeId { get; set; }
+
+    public User? User { get; set; }
+    public StreetcodeContent? Streetcode { get; set; }
+}

--- a/Streetcode/Streetcode.BLL/Mapping/FavouriteStreetcode/FavouriteStreetcodeProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/FavouriteStreetcode/FavouriteStreetcodeProfile.cs
@@ -3,7 +3,7 @@ using Streetcode.BLL.DTO.FavouriteStreetcode;
 
 namespace Streetcode.BLL.Mapping.FavouriteStreetcode;
 
-public class FavouriteStreetcodeProfile: Profile
+public class FavouriteStreetcodeProfile : Profile
 {
     public FavouriteStreetcodeProfile()
     {

--- a/Streetcode/Streetcode.BLL/Mapping/FavouriteStreetcode/FavouriteStreetcodeProfile.cs
+++ b/Streetcode/Streetcode.BLL/Mapping/FavouriteStreetcode/FavouriteStreetcodeProfile.cs
@@ -1,0 +1,12 @@
+﻿using AutoMapper;
+using Streetcode.BLL.DTO.FavouriteStreetcode;
+
+namespace Streetcode.BLL.Mapping.FavouriteStreetcode;
+
+public class FavouriteStreetcodeProfile: Profile
+{
+    public FavouriteStreetcodeProfile()
+    {
+        CreateMap<DAL.Entities.Favourite.FavouriteStreetcode, FavouriteStreetcodeDTO>().ReverseMap();
+    }
+}

--- a/Streetcode/Streetcode.BLL/MediatR/FavouriteStreetcode/Delete/DeleteFavouriteStreetcodeCommand.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/FavouriteStreetcode/Delete/DeleteFavouriteStreetcodeCommand.cs
@@ -1,0 +1,9 @@
+﻿using FluentResults;
+using MediatR;
+using Streetcode.BLL.DTO.FavouriteStreetcode;
+using Streetcode.DAL.Enums;
+
+namespace Streetcode.BLL.MediatR.FavouriteStreetcode.Delete;
+
+public record DeleteFavouriteStreetcodeCommand(int Id, int RequestingUserId, UserRole UserRole)
+    : IRequest<Result<FavouriteStreetcodeDTO>>;

--- a/Streetcode/Streetcode.BLL/MediatR/FavouriteStreetcode/Delete/DeleteFavouriteStreetcodeCommand.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/FavouriteStreetcode/Delete/DeleteFavouriteStreetcodeCommand.cs
@@ -5,5 +5,5 @@ using Streetcode.DAL.Enums;
 
 namespace Streetcode.BLL.MediatR.FavouriteStreetcode.Delete;
 
-public record DeleteFavouriteStreetcodeCommand(int Id, int RequestingUserId, UserRole UserRole)
+public record DeleteFavouriteStreetcodeCommand(int Id, int RequestingUserId)
     : IRequest<Result<FavouriteStreetcodeDTO>>;

--- a/Streetcode/Streetcode.BLL/MediatR/FavouriteStreetcode/Delete/DeleteFavouriteStreetcodeCommandHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/FavouriteStreetcode/Delete/DeleteFavouriteStreetcodeCommandHandler.cs
@@ -1,0 +1,71 @@
+﻿using AutoMapper;
+using FluentResults;
+using MediatR;
+using Streetcode.BLL.DTO.FavouriteStreetcode;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.Resources;
+using Streetcode.BLL.Util.Extensions;
+using Streetcode.DAL.Enums;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using Streetcode.DAL.Repositories.Realizations.FavouriteStreetcodes;
+
+namespace Streetcode.BLL.MediatR.FavouriteStreetcode.Delete;
+
+public class DeleteFavouriteStreetcodeCommandHandler
+    : IRequestHandler<DeleteFavouriteStreetcodeCommand, Result<FavouriteStreetcodeDTO>>
+{
+    private readonly IRepositoryWrapper _repositoryWrapper;
+    private readonly ILoggerService _logger;
+    private readonly IMapper _mapper;
+
+    public DeleteFavouriteStreetcodeCommandHandler(
+        IRepositoryWrapper repositoryWrapper,
+        ILoggerService logger,
+        IMapper mapper)
+    {
+        _repositoryWrapper = repositoryWrapper;
+        _logger = logger;
+        _mapper = mapper;
+    }
+
+    public async Task<Result<FavouriteStreetcodeDTO>> Handle(DeleteFavouriteStreetcodeCommand request, CancellationToken cancellationToken)
+    {
+        var favourite = await _repositoryWrapper.FavouriteStreetcodeRepository
+            .GetFirstOrDefaultAsync(f => f.Id == request.Id);
+
+        if (favourite == null)
+        {
+            string errorMsg = Errors_Common.NotFoundById.FormatWith("favourite streetcode", request.Id);
+            _logger.LogError(request, errorMsg);
+            return Result.Fail<FavouriteStreetcodeDTO>(errorMsg);
+        }
+
+        bool isAdmin = request.UserRole == UserRole.MainAdministrator
+                       || request.UserRole == UserRole.Administrator
+                       || request.UserRole == UserRole.Moderator;
+
+        bool isOwner = favourite.UserId == request.RequestingUserId;
+
+        if (!isAdmin && !isOwner)
+        {
+            string errorMsg = Errors_Common.UnauthorizedAction.FormatWith("delete this favourite streetcode");
+            _logger.LogError(request, errorMsg);
+            return Result.Fail<FavouriteStreetcodeDTO>(errorMsg);
+        }
+
+        _repositoryWrapper.FavouriteStreetcodeRepository.Delete(favourite);
+
+        var resultIsSuccess = await _repositoryWrapper.SaveChangesAsync() > 0;
+        if (resultIsSuccess)
+        {
+            var mappedFavourite = _mapper.Map<FavouriteStreetcodeDTO>(favourite);
+            return Result.Ok(mappedFavourite);
+        }
+        else
+        {
+            string errorMsg = Errors_Common.FailedToDelete.FormatWith("favourite streetcode");
+            _logger.LogError(request, errorMsg);
+            return Result.Fail<FavouriteStreetcodeDTO>(new Error(errorMsg));
+        }
+    }
+}

--- a/Streetcode/Streetcode.BLL/MediatR/FavouriteStreetcode/Delete/DeleteFavouriteStreetcodeHandler.cs
+++ b/Streetcode/Streetcode.BLL/MediatR/FavouriteStreetcode/Delete/DeleteFavouriteStreetcodeHandler.cs
@@ -7,18 +7,17 @@ using Streetcode.BLL.Resources;
 using Streetcode.BLL.Util.Extensions;
 using Streetcode.DAL.Enums;
 using Streetcode.DAL.Repositories.Interfaces.Base;
-using Streetcode.DAL.Repositories.Realizations.FavouriteStreetcodes;
 
 namespace Streetcode.BLL.MediatR.FavouriteStreetcode.Delete;
 
-public class DeleteFavouriteStreetcodeCommandHandler
+public class DeleteFavouriteStreetcodeHandler
     : IRequestHandler<DeleteFavouriteStreetcodeCommand, Result<FavouriteStreetcodeDTO>>
 {
     private readonly IRepositoryWrapper _repositoryWrapper;
     private readonly ILoggerService _logger;
     private readonly IMapper _mapper;
 
-    public DeleteFavouriteStreetcodeCommandHandler(
+    public DeleteFavouriteStreetcodeHandler(
         IRepositoryWrapper repositoryWrapper,
         ILoggerService logger,
         IMapper mapper)
@@ -40,13 +39,8 @@ public class DeleteFavouriteStreetcodeCommandHandler
             return Result.Fail<FavouriteStreetcodeDTO>(errorMsg);
         }
 
-        bool isAdmin = request.UserRole == UserRole.MainAdministrator
-                       || request.UserRole == UserRole.Administrator
-                       || request.UserRole == UserRole.Moderator;
-
-        bool isOwner = favourite.UserId == request.RequestingUserId;
-
-        if (!isAdmin && !isOwner)
+        // Only owner can delete
+        if (favourite.UserId != request.RequestingUserId)
         {
             string errorMsg = Errors_Common.UnauthorizedAction.FormatWith("delete this favourite streetcode");
             _logger.LogError(request, errorMsg);

--- a/Streetcode/Streetcode.BLL/Streetcode.BLL.csproj
+++ b/Streetcode/Streetcode.BLL/Streetcode.BLL.csproj
@@ -49,6 +49,7 @@
   <ItemGroup>
     <Folder Include="Mapping\Analytics\" />
     <Folder Include="Mapping\Comments\" />
+    <Folder Include="Mapping\FavouriteStreetcode\" />
     <Folder Include="MediatR\AdditionalContent\Tag\" />
     <Folder Include="Exceptions\" />
     <Folder Include="DTO\Instagram\" />

--- a/Streetcode/Streetcode.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
+++ b/Streetcode/Streetcode.DAL/Repositories/Interfaces/Base/IRepositoryWrapper.cs
@@ -57,7 +57,7 @@ public interface IRepositoryWrapper
     IStreetcodeToponymRepository StreetcodeToponymRepository { get; }
     IStreetcodeImageRepository StreetcodeImageRepository { get; }
     IRefreshTokenRepository RefreshTokenRepository { get; }
-    IFavouriteStreetcodeRepository FavoriteStreetcodeRepository { get; }
+    IFavouriteStreetcodeRepository FavouriteStreetcodeRepository { get; }
     public int SaveChanges();
 
     public Task<int> SaveChangesAsync();

--- a/Streetcode/Streetcode.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
+++ b/Streetcode/Streetcode.DAL/Repositories/Realizations/Base/RepositoryWrapper.cs
@@ -606,7 +606,7 @@ public class RepositoryWrapper : IRepositoryWrapper
         }
     }
 
-    public IFavouriteStreetcodeRepository FavoriteStreetcodeRepository
+    public IFavouriteStreetcodeRepository FavouriteStreetcodeRepository
     {
         get
         {

--- a/Streetcode/Streetcode.WebApi/Controllers/FavouriteStreetcode/FavouriteStreetcodeController.cs
+++ b/Streetcode/Streetcode.WebApi/Controllers/FavouriteStreetcode/FavouriteStreetcodeController.cs
@@ -1,11 +1,30 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Streetcode.BLL.MediatR.FavouriteStreetcode.Delete;
+using Streetcode.WebApi.Utils;
 
 namespace Streetcode.WebApi.Controllers.FavouriteStreetcode
 {
     [Route("api/[controller]")]
     [ApiController]
-    public class FavouriteStreetcodeController : ControllerBase
+    public class FavouriteStreetcodeController : BaseApiController
     {
+        [Authorize]
+        [HttpDelete("{id:int}")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> DeleteFavouriteStreetcode([FromRoute] int id, CancellationToken ct)
+        {
+            var userId = AuthHelper.GetUserId(HttpContext.User);
+
+            var command = new DeleteFavouriteStreetcodeCommand(id, userId);
+            var result = await Mediator.Send(command, ct);
+
+            return HandleResult(result);
+        }
     }
 }

--- a/Streetcode/Streetcode.XUnitTest/BLL/MediatR/FavouriteStreetcode/DeleteFavouriteStreetcodeTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/MediatR/FavouriteStreetcode/DeleteFavouriteStreetcodeTests.cs
@@ -1,0 +1,326 @@
+﻿using AutoMapper;
+using Microsoft.EntityFrameworkCore.Query;
+using Moq;
+using Streetcode.BLL.DTO.FavouriteStreetcode;
+using Streetcode.BLL.Interfaces.Logging;
+using Streetcode.BLL.MediatR.FavouriteStreetcode.Delete;
+using Streetcode.BLL.Resources;
+using Streetcode.BLL.Util.Extensions;
+using Streetcode.DAL.Repositories.Interfaces.Base;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace Streetcode.XUnitTest.BLL.MediatR.FavouriteStreetcode;
+
+public class DeleteFavouriteStreetcodeTests
+{
+    private readonly Mock<IRepositoryWrapper> _repositoryWrapperMock;
+    private readonly Mock<ILoggerService> _loggerMock;
+    private readonly Mock<IMapper> _mapperMock;
+    private readonly DeleteFavouriteStreetcodeHandler _handler;
+
+    public DeleteFavouriteStreetcodeTests()
+    {
+        _repositoryWrapperMock = new Mock<IRepositoryWrapper>();
+        _loggerMock = new Mock<ILoggerService>();
+        _mapperMock = new Mock<IMapper>();
+
+        _handler = new DeleteFavouriteStreetcodeHandler(
+            _repositoryWrapperMock.Object,
+            _loggerMock.Object,
+            _mapperMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_FavouriteNotFound_ReturnsFailureResult()
+    {
+        // Arrange
+        var command = new DeleteFavouriteStreetcodeCommand(1, 123);
+        var cancellationToken = CancellationToken.None;
+
+        _repositoryWrapperMock
+            .Setup(x => x.FavouriteStreetcodeRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<DAL.Entities.Favourite.FavouriteStreetcode, bool>>>(),
+                It.IsAny<Func<IQueryable<DAL.Entities.Favourite.FavouriteStreetcode>, IIncludableQueryable<DAL.Entities.Favourite.FavouriteStreetcode, object>>>()))
+            .ReturnsAsync((DAL.Entities.Favourite.FavouriteStreetcode?)null);
+
+        string expectedErrorMsg = Errors_Common.NotFoundById.FormatWith("favourite streetcode", command.Id);
+
+        // Act
+        var result = await _handler.Handle(command, cancellationToken);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Contains(expectedErrorMsg, result.Errors.Select(e => e.Message));
+
+        _loggerMock.Verify(
+            x => x.LogError(command, expectedErrorMsg),
+            Times.Once);
+    }
+
+    public async Task Handle_UnauthorizedUser_ReturnsFailureResult()
+    {
+        // Arrange
+        var command = new DeleteFavouriteStreetcodeCommand(1, 123);
+        var cancellationToken = CancellationToken.None;
+
+        var favourite = new DAL.Entities.Favourite.FavouriteStreetcode
+        {
+            Id = 1,
+            UserId = 456, // Different from requesting user
+            StreetcodeId = 789
+        };
+
+        _repositoryWrapperMock
+            .Setup(x => x.FavouriteStreetcodeRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<DAL.Entities.Favourite.FavouriteStreetcode, bool>>>(),
+                It.IsAny<Func<IQueryable<DAL.Entities.Favourite.FavouriteStreetcode>, IIncludableQueryable<DAL.Entities.Favourite.FavouriteStreetcode, object>>>()))
+            .ReturnsAsync(favourite);
+
+        string expectedErrorMsg = Errors_Common.UnauthorizedAction.FormatWith("delete this favourite streetcode");
+
+        // Act
+        var result = await _handler.Handle(command, cancellationToken);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Contains(expectedErrorMsg, result.Errors.Select(e => e.Message));
+
+        _loggerMock.Verify(
+            x => x.LogError(command, expectedErrorMsg),
+            Times.Once);
+
+        // Verify that Delete and SaveChanges were not called
+        _repositoryWrapperMock.Verify(x => x.FavouriteStreetcodeRepository.Delete(It.IsAny<DAL.Entities.Favourite.FavouriteStreetcode>()), Times.Never);
+        _repositoryWrapperMock.Verify(x => x.SaveChangesAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_AuthorizedUser_DeletesSuccessfully()
+    {
+        // Arrange
+        var command = new DeleteFavouriteStreetcodeCommand(1, 123);
+        var cancellationToken = CancellationToken.None;
+
+        var favourite = new DAL.Entities.Favourite.FavouriteStreetcode
+        {
+            Id = 1,
+            UserId = 123, // Same as requesting user
+            StreetcodeId = 789
+        };
+
+        var expectedFavouriteDto = new FavouriteStreetcodeDTO
+        {
+            Id = 1,
+            UserId = 123,
+            StreetcodeId = 789
+        };
+
+        _repositoryWrapperMock
+            .Setup(x => x.FavouriteStreetcodeRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<DAL.Entities.Favourite.FavouriteStreetcode, bool>>>(),
+                It.IsAny<Func<IQueryable<DAL.Entities.Favourite.FavouriteStreetcode>, IIncludableQueryable<DAL.Entities.Favourite.FavouriteStreetcode, object>>>()))
+            .ReturnsAsync(favourite);
+
+        _repositoryWrapperMock
+            .Setup(x => x.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        _mapperMock
+            .Setup(x => x.Map<FavouriteStreetcodeDTO>(favourite))
+            .Returns(expectedFavouriteDto);
+
+        // Act
+        var result = await _handler.Handle(command, cancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(expectedFavouriteDto, result.Value);
+
+        _repositoryWrapperMock.Verify(x => x.FavouriteStreetcodeRepository.Delete(favourite), Times.Once);
+        _repositoryWrapperMock.Verify(x => x.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_SaveChangesFails_ReturnsFailureResult()
+    {
+        // Arrange
+        var command = new DeleteFavouriteStreetcodeCommand(1, 123);
+        var cancellationToken = CancellationToken.None;
+
+        var favourite = new DAL.Entities.Favourite.FavouriteStreetcode
+        {
+            Id = 1,
+            UserId = 123, // Same as requesting user
+            StreetcodeId = 789
+        };
+
+        _repositoryWrapperMock
+            .Setup(x => x.FavouriteStreetcodeRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<DAL.Entities.Favourite.FavouriteStreetcode, bool>>>(),
+                It.IsAny<Func<IQueryable<DAL.Entities.Favourite.FavouriteStreetcode>, IIncludableQueryable<DAL.Entities.Favourite.FavouriteStreetcode, object>>>()))
+            .ReturnsAsync(favourite);
+
+        _repositoryWrapperMock
+            .Setup(x => x.SaveChangesAsync())
+            .ReturnsAsync(0); // No rows affected
+
+        string expectedErrorMsg = Errors_Common.FailedToDelete.FormatWith("favourite streetcode");
+
+        // Act
+        var result = await _handler.Handle(command, cancellationToken);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Contains(expectedErrorMsg, result.Errors.Select(e => e.Message));
+
+        _repositoryWrapperMock.Verify(x => x.FavouriteStreetcodeRepository.Delete(favourite), Times.Once);
+        _repositoryWrapperMock.Verify(x => x.SaveChangesAsync(), Times.Once);
+
+        _loggerMock.Verify(
+            x => x.LogError(command, expectedErrorMsg),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineData(1, 100)]
+    [InlineData(5, 200)]
+    [InlineData(10, 300)]
+    public async Task Handle_ValidRequestWithDifferentIds_DeletesSuccessfully(int favouriteId, int userId)
+    {
+        // Arrange
+        var command = new DeleteFavouriteStreetcodeCommand(favouriteId, userId);
+        var cancellationToken = CancellationToken.None;
+
+        var favourite = new DAL.Entities.Favourite.FavouriteStreetcode
+        {
+            Id = favouriteId,
+            UserId = userId, // Same as requesting user
+            StreetcodeId = 789
+        };
+
+        var expectedFavouriteDto = new FavouriteStreetcodeDTO
+        {
+            Id = favouriteId,
+            UserId = userId,
+            StreetcodeId = 789
+        };
+
+        _repositoryWrapperMock
+            .Setup(x => x.FavouriteStreetcodeRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<DAL.Entities.Favourite.FavouriteStreetcode, bool>>>(),
+                It.IsAny<Func<IQueryable<DAL.Entities.Favourite.FavouriteStreetcode>, IIncludableQueryable<DAL.Entities.Favourite.FavouriteStreetcode, object>>>()))
+            .ReturnsAsync(favourite);
+
+        _repositoryWrapperMock
+            .Setup(x => x.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        _mapperMock
+            .Setup(x => x.Map<FavouriteStreetcodeDTO>(favourite))
+            .Returns(expectedFavouriteDto);
+
+        // Act
+        var result = await _handler.Handle(command, cancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Equal(expectedFavouriteDto, result.Value);
+        Assert.Equal(favouriteId, result.Value.Id);
+        Assert.Equal(userId, result.Value.UserId);
+
+        _repositoryWrapperMock.Verify(x => x.FavouriteStreetcodeRepository.Delete(favourite), Times.Once);
+        _repositoryWrapperMock.Verify(x => x.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_SaveChangesReturnsNegativeValue_ReturnsFailureResult()
+    {
+        // Arrange
+        var command = new DeleteFavouriteStreetcodeCommand(1, 123);
+        var cancellationToken = CancellationToken.None;
+
+        var favourite = new DAL.Entities.Favourite.FavouriteStreetcode
+        {
+            Id = 1,
+            UserId = 123,
+            StreetcodeId = 789
+        };
+
+        _repositoryWrapperMock
+            .Setup(x => x.FavouriteStreetcodeRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<DAL.Entities.Favourite.FavouriteStreetcode, bool>>>(),
+                It.IsAny<Func<IQueryable<DAL.Entities.Favourite.FavouriteStreetcode>, IIncludableQueryable<DAL.Entities.Favourite.FavouriteStreetcode, object>>>()))
+            .ReturnsAsync(favourite);
+
+        _repositoryWrapperMock
+            .Setup(x => x.SaveChangesAsync())
+            .ReturnsAsync(-1); // Negative value indicating failure
+
+        string expectedErrorMsg = Errors_Common.FailedToDelete.FormatWith("favourite streetcode");
+
+        // Act
+        var result = await _handler.Handle(command, cancellationToken);
+
+        // Assert
+        Assert.True(result.IsFailed);
+        Assert.Contains(expectedErrorMsg, result.Errors.Select(e => e.Message));
+    }
+
+    [Fact]
+    public async Task Handle_RepositoryThrowsException_ExceptionPropagates()
+    {
+        // Arrange
+        var command = new DeleteFavouriteStreetcodeCommand(1, 123);
+        var cancellationToken = CancellationToken.None;
+
+        _repositoryWrapperMock
+            .Setup(x => x.FavouriteStreetcodeRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<DAL.Entities.Favourite.FavouriteStreetcode, bool>>>(),
+                It.IsAny<Func<IQueryable<DAL.Entities.Favourite.FavouriteStreetcode>, IIncludableQueryable<DAL.Entities.Favourite.FavouriteStreetcode, object>>>()))
+            .ThrowsAsync(new InvalidOperationException("Database error"));
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _handler.Handle(command, cancellationToken));
+    }
+
+    [Fact]
+    public async Task Handle_MapperReturnsNull_ReturnsSuccessWithNull()
+    {
+        // Arrange
+        var command = new DeleteFavouriteStreetcodeCommand(1, 123);
+        var cancellationToken = CancellationToken.None;
+
+        var favourite = new DAL.Entities.Favourite.FavouriteStreetcode
+        {
+            Id = 1,
+            UserId = 123,
+            StreetcodeId = 789
+        };
+
+        _repositoryWrapperMock
+            .Setup(x => x.FavouriteStreetcodeRepository.GetFirstOrDefaultAsync(
+                It.IsAny<Expression<Func<DAL.Entities.Favourite.FavouriteStreetcode, bool>>>(),
+                It.IsAny<Func<IQueryable<DAL.Entities.Favourite.FavouriteStreetcode>, IIncludableQueryable<DAL.Entities.Favourite.FavouriteStreetcode, object>>>()))
+            .ReturnsAsync(favourite);
+
+        _repositoryWrapperMock
+            .Setup(x => x.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        _mapperMock
+            .Setup(x => x.Map<FavouriteStreetcodeDTO>(favourite))
+            .Returns((FavouriteStreetcodeDTO?)null);
+
+        // Act
+        var result = await _handler.Handle(command, cancellationToken);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Null(result.Value);
+
+        _repositoryWrapperMock.Verify(x => x.FavouriteStreetcodeRepository.Delete(favourite), Times.Once);
+        _repositoryWrapperMock.Verify(x => x.SaveChangesAsync(), Times.Once);
+    }
+}

--- a/Streetcode/Streetcode.XUnitTest/BLL/MediatR/FavouriteStreetcode/DeleteFavouriteStreetcodeTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/MediatR/FavouriteStreetcode/DeleteFavouriteStreetcodeTests.cs
@@ -1,4 +1,5 @@
-﻿using AutoMapper;
+﻿using System.Linq.Expressions;
+using AutoMapper;
 using Microsoft.EntityFrameworkCore.Query;
 using Moq;
 using Streetcode.BLL.DTO.FavouriteStreetcode;
@@ -7,7 +8,6 @@ using Streetcode.BLL.MediatR.FavouriteStreetcode.Delete;
 using Streetcode.BLL.Resources;
 using Streetcode.BLL.Util.Extensions;
 using Streetcode.DAL.Repositories.Interfaces.Base;
-using System.Linq.Expressions;
 using Xunit;
 
 namespace Streetcode.XUnitTest.BLL.MediatR.FavouriteStreetcode;

--- a/Streetcode/Streetcode.XUnitTest/BLL/MediatR/FavouriteStreetcode/DeleteFavouriteStreetcodeTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/BLL/MediatR/FavouriteStreetcode/DeleteFavouriteStreetcodeTests.cs
@@ -58,6 +58,7 @@ public class DeleteFavouriteStreetcodeTests
             Times.Once);
     }
 
+    [Fact]
     public async Task Handle_UnauthorizedUser_ReturnsFailureResult()
     {
         // Arrange

--- a/Streetcode/Streetcode.XUnitTest/WebApi/Controllers/FavouriteStreetcodeControllerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/WebApi/Controllers/FavouriteStreetcodeControllerTests.cs
@@ -1,0 +1,78 @@
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Streetcode.BLL.DTO.FavouriteStreetcode;
+using Streetcode.BLL.MediatR.FavouriteStreetcode.Delete;
+using Streetcode.WebApi.Controllers.FavouriteStreetcode;
+using Xunit;
+using FluentResults;
+using System.Security.Claims;
+
+namespace Streetcode.XUnitTest.WebApi.Controllers;
+
+public class FavouriteStreetcodeControllerTests
+{
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly Mock<IServiceProvider> _serviceProviderMock;
+    private readonly FavouriteStreetcodeController _controller;
+
+    public FavouriteStreetcodeControllerTests()
+    {
+        _mediatorMock = new Mock<IMediator>();
+        _serviceProviderMock = new Mock<IServiceProvider>();
+
+        _serviceProviderMock.Setup(x => x.GetService(typeof(IMediator)))
+            .Returns(_mediatorMock.Object);
+
+        _controller = new FavouriteStreetcodeController();
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.RequestServices = _serviceProviderMock.Object;
+
+        var claims = new List<Claim>
+        {
+            new Claim(ClaimTypes.NameIdentifier, "1")
+        };
+        httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = httpContext
+        };
+    }
+
+    [Fact]
+    public async Task DeleteFavouriteStreetcode_ShouldReturnOk_WhenResultIsSuccess()
+    {
+        // Arrange
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<DeleteFavouriteStreetcodeCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Ok(new FavouriteStreetcodeDTO()));
+
+        // Act
+        var result = await _controller.DeleteFavouriteStreetcode(1, CancellationToken.None);
+
+        // Assert
+        Assert.IsType<OkObjectResult>(result);
+        _mediatorMock.VerifyAll();
+    }
+
+    [Fact]
+    public async Task DeleteFavouriteStreetcode_ShouldReturnBadRequest_WhenResultIsFailure()
+    {
+        // Arrange
+        _mediatorMock
+            .Setup(x => x.Send(It.IsAny<DeleteFavouriteStreetcodeCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Fail<FavouriteStreetcodeDTO>("Test error"));
+
+        // Act
+        var result = await _controller.DeleteFavouriteStreetcode(1, CancellationToken.None);
+
+        // Assert
+        Assert.IsType<BadRequestObjectResult>(result);
+        _mediatorMock.VerifyAll();
+    }
+}
+
+

--- a/Streetcode/Streetcode.XUnitTest/WebApi/Controllers/FavouriteStreetcodeControllerTests.cs
+++ b/Streetcode/Streetcode.XUnitTest/WebApi/Controllers/FavouriteStreetcodeControllerTests.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -7,7 +8,6 @@ using Streetcode.BLL.MediatR.FavouriteStreetcode.Delete;
 using Streetcode.WebApi.Controllers.FavouriteStreetcode;
 using Xunit;
 using FluentResults;
-using System.Security.Claims;
 
 namespace Streetcode.XUnitTest.WebApi.Controllers;
 
@@ -74,5 +74,3 @@ public class FavouriteStreetcodeControllerTests
         _mediatorMock.VerifyAll();
     }
 }
-
-


### PR DESCRIPTION
dev

- [ ] @weazy12 
- [ ] @VladysMoroz 
- [ ] @oleksandrhofner 
- [ ] @Skiper29 

## Summary of issue

Issues:
- https://github.com/project-studying-dotnet/Streetcode-Server-August-2025/issues/231- [Task][User/Favorite] Add endpoint Delete


## Summary of change

This pull request adds the ability for users to remove favourite streetcodes. The deletion logic ensures that only the owner of a favourite streetcode can delete it. Supporting command, handler, and controller endpoint were introduced. Added test coverage

## Changes introduced

- Added DeleteFavouriteStreetcodeCommand record with Id and RequestingUserId.
- Implemented DeleteFavouriteStreetcodeCommandHandler to handle deletion with ownership validation.
- Added controller endpoint DeleteFavouriteStreetcode ([HttpDelete("{id:int}")]) for removing favourite streetcodes.
- Integrated authorization check to ensure only the owner can delete their favourite entry.

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authorized DELETE endpoint to remove a favourite streetcode; returns clear success/failure responses.
  * New DTO representing a user's favourited streetcode relationship.

* **Refactor**
  * Naming standardized to “Favourite” across the system for consistency (no user-facing behavior change).

* **Tests**
  * Comprehensive unit tests covering deletion scenarios: not found, unauthorized, successful deletion, save failures, exceptions, and mapping edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->