### PR TITLE
Add Azure CI/CD pipeline configuration

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -1,0 +1,59 @@
+name: Azure CI/CD Pipeline
+on:
+  push:
+    branches:
+    - main
+
+env:
+  AZURE_WEBAPP_NAME: streetcode-web-api
+  AZURE_WEBAPP_PACKAGE_PATH: Streetcode/Streetcode.WebApi/publish
+  CONFIGURATION: Release
+  DOTNET_CORE_VERSION: 8.0.x
+  WORKING_DIRECTORY: Streetcode/Streetcode.WebApi
+
+jobs:
+  build:
+    runs-on: windows-latest  
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: ${{ env.DOTNET_CORE_VERSION }}
+    - name: Restore Dependencies
+      run: dotnet restore ${{ env.WORKING_DIRECTORY }}
+    - name: Build
+      run: dotnet build ${{ env.WORKING_DIRECTORY }} --configuration ${{ env.CONFIGURATION }} --no-restore
+    - name: Test
+      run: dotnet test ${{ env.WORKING_DIRECTORY }} --no-build
+    - name: Publish
+      run: dotnet publish ${{ env.WORKING_DIRECTORY }} --configuration ${{ env.CONFIGURATION }} --no-build --output ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: webapp
+        path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+  deploy:
+    runs-on: windows-latest
+    needs: build
+    steps:
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: webapp
+        path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+    - name: Login to Azure
+      uses: azure/login@v2
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+    - name: Deploy to Azure Web App
+      uses: azure/webapps-deploy@v3
+      with:
+        app-name: ${{ env.AZURE_WEBAPP_NAME }}
+        package: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
+    - name: logout
+      run: >
+        az logout
+
+        

--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -10,6 +10,7 @@ env:
   CONFIGURATION: Release
   DOTNET_CORE_VERSION: 8.0.x
   WORKING_DIRECTORY: Streetcode/Streetcode.WebApi
+  TEST_DIRECTORY: ./Streetcode/Streetcode.XUnitTest/Streetcode.XUnitTest.csproj
 
 jobs:
   build:
@@ -26,7 +27,7 @@ jobs:
     - name: Build
       run: dotnet build ${{ env.WORKING_DIRECTORY }} --configuration ${{ env.CONFIGURATION }} --no-restore
     - name: Test
-      run: dotnet test ${{ env.WORKING_DIRECTORY }} --no-build
+      run: dotnet test ${{ env.TEST_DIRECTORY }} --no-build
     - name: Publish
       run: dotnet publish ${{ env.WORKING_DIRECTORY }} --configuration ${{ env.CONFIGURATION }} --no-build --output ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}
     - name: Upload build artifacts


### PR DESCRIPTION
dev

## Code reviewers

- [ ] @weazy12
- [ ] @Markian-Grybok
- [ ] @denys-pavskyi
- [ ] @oleksandrhofner

## Summary of issue

- https://github.com/project-studying-dotnet/Streetcode-Server-August-2025/issues/224

## Summary of change

This pull request introduces a new GitHub Actions workflow to automate the build and deployment process for the `streetcode-web-api` project using Azure services. The workflow is triggered on pushes to the `main` branch and includes separate jobs for building, testing, and deploying the application.

**CI/CD Pipeline Setup:**

* Added `.github/workflows/azure-deploy.yml` to define a CI/CD pipeline that builds, tests, and deploys the `streetcode-web-api` project to Azure Web Apps on pushes to the `main` branch.
  * The pipeline includes steps for checking out code, setting up the .NET SDK, restoring dependencies, building, testing, publishing, uploading artifacts, and deploying to Azure.
  * Deployment uses Azure credentials stored in repository secrets and uploads the published output to the specified Azure Web App.
 
Closes #224

## CHECK LIST
- [ ]  СI passed
- [ ]  Сode coverage >=95%
- [ ]  PR is reviewed manually again (to make sure you have 100% ready code)
- [ ]  All reviewers agreed to merge the PR
- [ ]  I've checked new feature as logged in and logged out user if needed
- [ ]  PR meets all conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated CI/CD pipeline to build, test, package, and deploy the web app to Azure after successful builds.
  * Packages and shares build artifacts between build and deploy stages for consistent releases.
  * Uses configured environment settings to streamline and speed up deployments, improving reliability and repeatability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->